### PR TITLE
Expose provider-specific search guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,12 +563,15 @@ Minimal config:
 - Supports `web_search`, `web_contents`, `web_answer`, and `web_research`
 - `web_research` is exposed through pi's async research workflow
 - Web, proprietary, and news search types
-- Exposes search options `searchType`, `responseLength`, and `countryCode`
+- Exposes search options such as `searchType`, `responseLength`,
+  `countryCode`, source filters, date filters, `fastMode`, `urlOnly`, and
+  `instructions`
+- Exposes contents options such as `summary`, `extractEffort`,
+  `responseLength`, `maxPriceDollars`, and `screenshot`
 - Exposes answer and research options `responseLength` and `countryCode`
 - Persisted Valyu defaults are scoped under `providers.valyu.options.search`,
-  `providers.valyu.options.answer`, and `providers.valyu.options.research`
-- `web_contents` currently uses fixed provider behavior with no extra per-call
-  provider options
+  `providers.valyu.options.contents`, `providers.valyu.options.answer`, and
+  `providers.valyu.options.research`
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -496,8 +496,7 @@ call.
 <summary><strong>Parallel</strong></summary>
 
 - SDK: `parallel-web`
-- Search modes `advanced`, `basic`, and `turbo`; legacy `agentic` and
-  `one-shot` configs are accepted as aliases
+- Search modes `advanced`, `basic`, and `turbo`
 - Page content extraction with excerpt and full-content toggles
 - Exposes search option `mode`
 - Exposes contents options `excerpts` and `full_content`

--- a/changelog/unreleased/.gitkeep
+++ b/changelog/unreleased/.gitkeep
@@ -1,0 +1,5 @@
+# Keep this directory tracked.
+#
+# Release creation moves changelog entries into releases/<version>/entries.
+# Keeping unreleased/ present prevents Git from inferring a directory
+# rename and moving entries from long-lived branches into a release.

--- a/changelog/unreleased/parallel-compatibility-with-the-current-sdk.md
+++ b/changelog/unreleased/parallel-compatibility-with-the-current-sdk.md
@@ -10,5 +10,3 @@ created: 2026-06-13T08:36:20.004187Z
 ---
 
 Parallel-backed `web_search` and `web_contents` continue to work with the current Parallel SDK.
-
-Existing configurations that use the legacy `agentic` or `one-shot` search modes keep working: `agentic` maps to the Parallel `advanced` mode, and `one-shot` maps to the lower-latency `basic` mode.

--- a/changelog/unreleased/provider-specific-web-tool-guidance.md
+++ b/changelog/unreleased/provider-specific-web-tool-guidance.md
@@ -1,0 +1,36 @@
+---
+title: Provider-specific web tool guidance
+type: feature
+authors:
+  - mavam
+  - codex
+prs:
+  - 21
+created: 2026-06-21T10:53:33.485622Z
+---
+
+Provider-specific web tool guidance is now surfaced in the registered `web_search` tool, making it easier for agents to choose provider-specific options such as source filters, recency controls, search depth, and provider modes.
+
+Valyu exposes more of its provider options for `web_search` and `web_contents`, including source filters, date filters, `summary`, `extractEffort`, `responseLength`, `maxPriceDollars`, and `screenshot`:
+
+```json
+{
+  "tools": {
+    "search": "valyu",
+    "contents": "valyu"
+  },
+  "providers": {
+    "valyu": {
+      "credentials": {
+        "api": "VALYU_API_KEY"
+      },
+      "options": {
+        "contents": {
+          "summary": true,
+          "responseLength": "medium"
+        }
+      }
+    }
+  }
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,18 +9,18 @@
       "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.177",
-        "@google/genai": "^2.8.0",
-        "@mendable/firecrawl-js": "^4.25.4",
-        "@openai/codex-sdk": "^0.139.0",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.185",
+        "@google/genai": "^2.9.0",
+        "@mendable/firecrawl-js": "^4.28.2",
+        "@openai/codex-sdk": "^0.141.0",
         "@perplexity-ai/perplexity_ai": "^0.33.0",
         "@tavily/core": "^0.7.6",
         "cloudflare": "^6.4.0",
-        "exa-js": "^2.13.0",
+        "exa-js": "^2.14.0",
         "linkup-sdk": "^3.2.5",
-        "openai": "^6.42.0",
+        "openai": "^6.44.0",
         "parallel-web": "^1.1.0",
-        "valyu-js": "^2.8.0"
+        "valyu-js": "^2.9.0"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
@@ -43,22 +43,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.177.tgz",
-      "integrity": "sha512-CBzXnzR661q3AlfZzBjmIFQx0cxr36iJV3PExTYmPyGQX32qxtiFQgnxTcF8wB4hcSVf2hnoy/gprVJdkNx7cw==",
+      "version": "0.3.185",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.185.tgz",
+      "integrity": "sha512-UDDd0cInvOufmR88btR/Ursnh71sb5scoutNlRS2L0LBdkt7JEqYJ0jt7DnOYHEVhMx8AAcg0eYgvXztcWUnFA==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.177",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.177"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.185",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.185",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.185",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.185",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.185",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.185",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.185",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.185"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.177.tgz",
-      "integrity": "sha512-u9Ty+KPllm2nw0RatdPF0zcPRquNZjVptmyLG0DqduGbgZDLQpfPFMF5hffFIRnVaXhx7+jkUmEdw0jrda0UcA==",
+      "version": "0.3.185",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.185.tgz",
+      "integrity": "sha512-P2Svxx1IFrS9aw4ylJBtcoJrc/OAOVnDs+o05x4TV7HoHUQUcKZ9XhWOGnadyVT0KLyoktgjyjnaK7Zdtc0Ldg==",
       "cpu": [
         "arm64"
       ],
@@ -80,9 +80,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.177.tgz",
-      "integrity": "sha512-ona6Jv54XFwBTqOj3MzLWfKtc2m7Rdh58wOAX9Hnue/6FcWfyeuz/UDcidVTXQ7Xytz//Tb0JJgFtiQjO7FbIA==",
+      "version": "0.3.185",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.185.tgz",
+      "integrity": "sha512-H69m2hIJawzSkCDNO/CPLQCYvDGdlbZdzGTgGF8/IQuB4O81sv8WSAh6TBXwtFXOgEi4HtrUYlxiFDmTHt7hMA==",
       "cpu": [
         "x64"
       ],
@@ -93,9 +93,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.177.tgz",
-      "integrity": "sha512-wBCbklkaDb483Ab4DUFfmJjZJKXz58YXPv+CiGsyjq1St19mbKEma5KKz3Ya9mlV8aLyh4zmLK2mEHPnF//Ipg==",
+      "version": "0.3.185",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.185.tgz",
+      "integrity": "sha512-KtXMCoprGYTSPb/A0/kjrO+PpDJAFbHhDd8rjqA4izU51OYjTDkahsGCcSTFM2jA8krOhPqzx/SNVuAVWmexwA==",
       "cpu": [
         "arm64"
       ],
@@ -109,9 +109,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.177.tgz",
-      "integrity": "sha512-v6PMDD3h2erLuTK5S2ZvExqdL3v44OyC70XpKhyqIUnyPaGR9YAMjh//EKdWC+mNvt6mIbRZpaDcHtbASVW8Rw==",
+      "version": "0.3.185",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.185.tgz",
+      "integrity": "sha512-1GRpKYrg5foomW+qLrxm/k2R/5PEU7RAuEdX65HV6lFMJR3HsGj8qfBq4KCJHTS3r4YdVrFLvPQ/mUqbY6klIA==",
       "cpu": [
         "arm64"
       ],
@@ -125,9 +125,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.177.tgz",
-      "integrity": "sha512-WDP6puwPHscggNAfvIxyUSHSAjfUEkGRfnMXEPBHOqO+qjX2KGxeE13/ih3EVioeBVOUIqPui6VB05vXLa6T9Q==",
+      "version": "0.3.185",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.185.tgz",
+      "integrity": "sha512-8U5wu6dNcyzRkwoae0Gu5ZHs6lRSu8CXqd9yrilX3fHR9kKICrm76bLu5q2auuSc/8dx6VL5ZXqSzFKIMp//zw==",
       "cpu": [
         "x64"
       ],
@@ -141,9 +141,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.177.tgz",
-      "integrity": "sha512-1cdEO06WoEsl1JnnLCPIlg/8x37GtBsTuj65gIpSjdrImNBjgIuMWVyceP4qaXhFjtQgYK1nx3TpaxEFVDOrDg==",
+      "version": "0.3.185",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.185.tgz",
+      "integrity": "sha512-YAky0Oez+YYrlcas/xDiaCm9AUX0z1YwM+pnk+CFxEr/ICmc7MbiFsnEIXFLPHaox9bE5iOzw4LS4b/c1tIJRg==",
       "cpu": [
         "x64"
       ],
@@ -157,9 +157,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.177.tgz",
-      "integrity": "sha512-xLgDWnZaYohtFrkgEIkGZdP+rp4sXxAMbbpEvEp0LK1vAYmJam/ztT2yoK6gfI58IbToJq1WGUEX2HVnE65yOg==",
+      "version": "0.3.185",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.185.tgz",
+      "integrity": "sha512-pJEOaCLQQQWSyBeseR/GAn4eEp4WtMDP/o5yPMuuAsNWeoJXM7cY4j/N3KBE6GZofgnYdWEXILF2uw3SjbtINA==",
       "cpu": [
         "arm64"
       ],
@@ -170,9 +170,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.177",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.177.tgz",
-      "integrity": "sha512-SIdQLbtF//rYK4KDBNpUPyjyui7NwCFPZ2/3vyW3TR8R8xynkNq3cLis90FnPSgxaSshi38vkJYWh+9kGDB7zg==",
+      "version": "0.3.185",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.185.tgz",
+      "integrity": "sha512-/Kf9XneSuIkSHNwrxOVY0XT7RovAEcx5nDASKzku4994cZz54otU5mT2jT6dwevDLEStfgts5x/A4z0AePwVTQ==",
       "cpu": [
         "x64"
       ],
@@ -3391,9 +3391,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.8.0.tgz",
-      "integrity": "sha512-pc2ayxqO5+O7AvnHBqpNHIk7PAZkHZgL31tbyx0gJZBSS9qPYiQoqwK7oYOw/ePmG6QY4EMSu+304vD5QlhXAw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.9.0.tgz",
+      "integrity": "sha512-3DRdSJ0LaKFig3FNGeRDn9BQxtjZm2qr0hNH2d771LKcG0HvUYddlN0LPdSp8XU7Ekb04i9q3+tt64uYqavUdw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3494,12 +3494,12 @@
       "license": "MIT"
     },
     "node_modules/@mendable/firecrawl-js": {
-      "version": "4.25.4",
-      "resolved": "https://registry.npmjs.org/@mendable/firecrawl-js/-/firecrawl-js-4.25.4.tgz",
-      "integrity": "sha512-kjtEdRAaIYD/rOU8Gk/uKgSjexMJYvXipGqAFy23VJ7UQpwtavcGGIB+iGecNvhMT2BJL1yBq2dED/mu5sj9sg==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/@mendable/firecrawl-js/-/firecrawl-js-4.28.2.tgz",
+      "integrity": "sha512-OijCdgSdS+wWzaUvGoA1Orthc/is8k1GNmYNQo5b2GdfW2mTLVZpYGQQzujXUxnbT/PFx5DCuvWGtmolX/PbAA==",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.16.1",
+        "axios": "1.18.0",
         "firecrawl": "4.16.0",
         "typescript-event-target": "^1.1.1",
         "zod": "^3.23.8",
@@ -3600,9 +3600,9 @@
       "license": "MIT"
     },
     "node_modules/@openai/codex": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0.tgz",
-      "integrity": "sha512-wr2fRE+fzW0CjEbfFsLh1ftarVEcw0CMLWS7QyA0nyOz5qacQPVq3cq2+/U7oEbwm1TOqoi0Fm1nxniB5FkpmA==",
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0.tgz",
+      "integrity": "sha512-ACpAn/Z7JwBg431040zKOLpBtNdP024ixqwC/R2YM5tPrLG0wfSmrd/AVHPUExt6hOO6fEHwxM/ixAyzFleQXw==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -3611,19 +3611,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.139.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.139.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.139.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.139.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.139.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.139.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.139.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0-darwin-arm64.tgz",
-      "integrity": "sha512-o+0ZKWwgDFMMLO7rwinzO0PQsgK+Vme1pMN2GeAxsX29ZgGZcyPICfpJbeGSUO1mb2a36Skjx6nfdRnxMY0r7w==",
+      "version": "0.141.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-darwin-arm64.tgz",
+      "integrity": "sha512-BuroZvQQLJYLfQEG7MKMdxHtggDDlxeJCTot//MwEnbW8ga7P319EPos/FyOK9r/gh+E/KGxk+YAzEoHZPRGEg==",
       "cpu": [
         "arm64"
       ],
@@ -3638,9 +3638,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.139.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0-darwin-x64.tgz",
-      "integrity": "sha512-9gkBWzu6DB2rqU4DbpxD3DE5bofGpsK46Lp0h0I+bKWc2IIcxvSi8K2utKmBLoJCbKrn4JQu7dFNGRqEfENung==",
+      "version": "0.141.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-darwin-x64.tgz",
+      "integrity": "sha512-kDP+egfjp3cuao1r9AdD8/skBxM7saT007VE82DB9mRUcqgKaxYHoPaHmKhlYOlFwPam0zsD6ORT6GJJhvGAKg==",
       "cpu": [
         "x64"
       ],
@@ -3655,9 +3655,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.139.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0-linux-arm64.tgz",
-      "integrity": "sha512-tBQE5lZciRHeWZGuURgjP9S717MvTIpQMc593+DNxY2LQxozkngOkzFSQd1+/UmQKGrCqdFLu5irIwPXpSZyEw==",
+      "version": "0.141.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-linux-arm64.tgz",
+      "integrity": "sha512-jXAOSjMqAUUgfMo9ciAkioJKKAYDwOE40bLx4/2jR7Tfu4u9409X5fQlLuNLMgnlfuzUEk/UiibQE62a70bQaw==",
       "cpu": [
         "arm64"
       ],
@@ -3672,9 +3672,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.139.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0-linux-x64.tgz",
-      "integrity": "sha512-14UgzDS+X4crkvdt6S02A/ZZOrS8ZyWiuTRpguCtnhNamb7unSuDxy86BWgpAl3sqiTaN2CP8VLyp2ohQ8Nbzw==",
+      "version": "0.141.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-linux-x64.tgz",
+      "integrity": "sha512-q3xv538DT/Sb8rRq8apdKgrgA/isqs1fDfE5JhRDMmojYFA3zwDldlmdWWGdS3APtjf5UrDsqljSE9JHxnlWNA==",
       "cpu": [
         "x64"
       ],
@@ -3688,12 +3688,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.139.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.139.0.tgz",
-      "integrity": "sha512-r4lDckaVx4mVZy1v/7ykEhkeWjVfM/4oGJfhG0AP4+zN3Sa+jcf5hdY4EHfJasofBcp0tIF/7JCKHpv534R+tw==",
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.141.0.tgz",
+      "integrity": "sha512-VCLsSJGSoOHcVAC/2+NrhtiBiCP/XF8YmCzzGocm8qNkAPN3a/+CcrvwUmvNSH53dU3TVi5Hp5zddov16BXLHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.139.0"
+        "@openai/codex": "0.141.0"
       },
       "engines": {
         "node": ">=18"
@@ -3701,9 +3701,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.139.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0-win32-arm64.tgz",
-      "integrity": "sha512-nlwRjsYotH1Rtqu/Q0VwQbIeO2UX1mkHK84Ov9qn/hl29QqqoBtno0tRyqIPbkXFIVQuWiAYXlV3ugLwH5fTrQ==",
+      "version": "0.141.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-win32-arm64.tgz",
+      "integrity": "sha512-87X5tvH1RmKQOHbgO5Cv+S0aXJ+saHTSSHEasJjbB1FtUoLbao29NTnkpkB2dAV3xtUJ/dmE8NgvbFEeWuMqUQ==",
       "cpu": [
         "arm64"
       ],
@@ -3718,9 +3718,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.139.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.139.0-win32-x64.tgz",
-      "integrity": "sha512-lQrVLNz+90wdvWVNFDvCkHQRiAK9ZllmkTka3c8eqSDqdJk35Gpgppfv9Xtw5M2ZBtTq0sBdWBiCMyzGDBSpmQ==",
+      "version": "0.141.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-win32-x64.tgz",
+      "integrity": "sha512-4gur4DgFQIOc+DopNOI90IpNA66qBIyc5Lb5QYy66OOCXOvXpbOCpScuEFmT1xpaTzNUYhlRGA2NFWqSHQrKUQ==",
       "cpu": [
         "x64"
       ],
@@ -4528,9 +4528,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+      "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -5026,9 +5026,9 @@
       }
     },
     "node_modules/exa-js": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/exa-js/-/exa-js-2.13.0.tgz",
-      "integrity": "sha512-G6BCMCMWdqVKKaKkNxHB5R/7xoT8JXVkdZ1nfaBejlMH90T95rlmEYdu2WJI2ZKEIm755vFLlNSobgVNPJCbYg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/exa-js/-/exa-js-2.14.0.tgz",
+      "integrity": "sha512-oTeVPJZ3cUkZNcIQvslyVpmGqp98caQwkmApJAYoGKr4GC2Uc8kETdeCffnegaKiFZNOMr6pQLH9/t6Z3tYc/A==",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "~4.1.0",
@@ -6288,9 +6288,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.42.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.42.0.tgz",
-      "integrity": "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg==",
+      "version": "6.44.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.44.0.tgz",
+      "integrity": "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "ws": "^8.18.0",
@@ -7068,9 +7068,9 @@
       }
     },
     "node_modules/valyu-js": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/valyu-js/-/valyu-js-2.8.0.tgz",
-      "integrity": "sha512-3DTVvVuUScs213a7E1YMflRLAaKfAeFozq7h+0hTi8Lo8pfYjSDU6vDWdJRDY1pHVMmgFsHNAwDoA7Orus/UEg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/valyu-js/-/valyu-js-2.9.0.tgz",
+      "integrity": "sha512-xWi6ccK4uSp2YZQxWYbIesl+3YvffQ3waVyUDagsGM9LVVJSm8Xt9LTEiWbyNrvjJScZswqQcKSOHqKhoNfi9Q==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.0"

--- a/package.json
+++ b/package.json
@@ -65,18 +65,18 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.177",
-    "@google/genai": "^2.8.0",
-    "@mendable/firecrawl-js": "^4.25.4",
-    "@openai/codex-sdk": "^0.139.0",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.185",
+    "@google/genai": "^2.9.0",
+    "@mendable/firecrawl-js": "^4.28.2",
+    "@openai/codex-sdk": "^0.141.0",
     "@perplexity-ai/perplexity_ai": "^0.33.0",
     "@tavily/core": "^0.7.6",
     "cloudflare": "^6.4.0",
-    "exa-js": "^2.13.0",
+    "exa-js": "^2.14.0",
     "linkup-sdk": "^3.2.5",
-    "openai": "^6.42.0",
+    "openai": "^6.44.0",
     "parallel-web": "^1.1.0",
-    "valyu-js": "^2.8.0"
+    "valyu-js": "^2.9.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -1222,10 +1222,10 @@ function ensureOpenAIResearchOptions(config: OpenAI): OpenAIResearchOptions {
   return config.options.research ?? (config.options.research = {});
 }
 
-function getValyuCapabilityOptions(
+function getValyuCapabilityOptions<TCapability extends keyof ValyuOptions>(
   config: Valyu | undefined,
-  capability: keyof ValyuOptions,
-) {
+  capability: TCapability,
+): ValyuOptions[TCapability] | undefined {
   return config?.options?.[capability];
 }
 

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -647,15 +647,8 @@ const PROVIDER_SETTINGS = {
       valuesSetting<Parallel>({
         id: "parallelSearchMode",
         label: "Search mode",
-        help: "Parallel search mode. 'default' uses the SDK default. Legacy 'agentic' and 'one-shot' values are accepted as aliases.",
-        values: [
-          "default",
-          "advanced",
-          "basic",
-          "turbo",
-          "agentic",
-          "one-shot",
-        ],
+        help: "Parallel search mode. 'default' uses the SDK default.",
+        values: ["default", "advanced", "basic", "turbo"],
         getValue: (config) =>
           readString(getParallelOptions(config)?.search?.mode) ?? "default",
         setValue: (config, value) => {

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -9,10 +9,10 @@ import type {
   Tool,
   ToolOutput,
 } from "../types.js";
+import { defineCapability, defineProvider } from "./definition.js";
 import { literalUnion } from "./schema.js";
 import { trimSnippet } from "./shared.js";
 
-import { defineCapability, defineProvider } from "./definition.js";
 const SEARCH_OUTPUT_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -111,6 +111,12 @@ const claudeOptionsSchema = Type.Object(
   },
   { description: "Claude options." },
 );
+
+const claudeSearchPromptGuidelines = [
+  "Use Claude search when Claude Code's agentic web-browsing and synthesis are useful for finding likely sources.",
+  "Increase effort or maxTurns only for difficult, ambiguous, or multi-step source discovery; keep defaults for simple searches.",
+  "Prefer web_contents after Claude search when the task requires direct inspection of a small set of selected URLs.",
+] as const;
 
 const claudeImplementation = {
   id: "claude" as const,
@@ -447,6 +453,7 @@ export const claudeProvider = defineProvider({
   capabilities: {
     search: defineCapability({
       options: claudeImplementation.getToolOptionsSchema?.("search"),
+      promptGuidelines: claudeSearchPromptGuidelines,
       async execute(input: any, ctx) {
         const { query, maxResults, options } = input;
         return await claudeImplementation.search!(

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -61,6 +61,12 @@ const codexSearchOptionsSchema = Type.Object(
   { description: "Codex search options." },
 );
 
+const codexSearchPromptGuidelines = [
+  "Use Codex search when the local Codex SDK should perform web-backed source discovery, especially for coding or developer-oriented investigations.",
+  "Use webSearchMode='live' for current information and 'cached' when freshness is less important; do not set 'disabled' for normal web_search calls.",
+  "Increase modelReasoningEffort only for difficult or ambiguous searches where deeper reasoning is worth the extra latency.",
+] as const;
+
 const codexImplementation = {
   id: "codex" as const,
   label: "Codex",
@@ -304,6 +310,7 @@ export const codexProvider = defineProvider({
   capabilities: {
     search: defineCapability({
       options: codexImplementation.getToolOptionsSchema?.("search"),
+      promptGuidelines: codexSearchPromptGuidelines,
       async execute(input: any, ctx) {
         const { query, maxResults, options } = input;
         return await codexImplementation.search!(

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -14,6 +14,7 @@ import type {
   Tool,
   ToolOutput,
 } from "../types.js";
+import { defineCapability, defineProvider } from "./definition.js";
 import { literalUnion } from "./schema.js";
 import {
   asJsonObject,
@@ -21,8 +22,6 @@ import {
   getApiKeyStatus,
   trimSnippet,
 } from "./shared.js";
-
-import { defineCapability, defineProvider } from "./definition.js";
 
 const exaSearchOptionsSchema = Type.Object(
   {
@@ -105,6 +104,13 @@ const exaSearchOptionsSchema = Type.Object(
   },
   { description: "Exa search options." },
 );
+
+const exaSearchPromptGuidelines = [
+  "Use Exa's neural/auto search modes for semantic source discovery where exact keywords are uncertain; use keyword mode when exact terms, names, or identifiers matter.",
+  "Use Exa category filters such as 'research paper' or 'company' when the user asks for a specific source type.",
+  "Set includeDomains or excludeDomains when the task names preferred sources, requires primary sources, or needs noisy domains filtered out.",
+  "Request contents.text, contents.highlights, or contents.summary only when snippets are insufficient and richer source context is needed directly in search results.",
+] as const;
 
 const exaImplementation = {
   id: "exa" as const,
@@ -355,6 +361,7 @@ export const exaProvider = defineProvider({
   capabilities: {
     search: defineCapability({
       options: exaImplementation.getToolOptionsSchema?.("search"),
+      promptGuidelines: exaSearchPromptGuidelines,
       async execute(input: any, ctx) {
         const { query, maxResults, options } = input;
         return await exaImplementation.search!(

--- a/src/providers/firecrawl.ts
+++ b/src/providers/firecrawl.ts
@@ -15,6 +15,7 @@ import type {
   ToolOutput,
   Tool,
 } from "../types.js";
+import { defineCapability, defineProvider } from "./definition.js";
 import { literalUnion } from "./schema.js";
 import {
   asJsonObject,
@@ -22,8 +23,6 @@ import {
   getApiKeyStatus,
   trimSnippet,
 } from "./shared.js";
-
-import { defineCapability, defineProvider } from "./definition.js";
 
 const FIRECRAWL_CLOUD_HOST = "api.firecrawl.dev";
 const FIRECRAWL_DEFAULT_API_URL = "https://api.firecrawl.dev";
@@ -87,6 +86,13 @@ const firecrawlSearchOptionsSchema = Type.Object(
   },
   { description: "Firecrawl search options." },
 );
+
+const firecrawlSearchPromptGuidelines = [
+  "Use Firecrawl search when the task benefits from searchable results that can also include scraped page content through scrapeOptions.",
+  "Set scrapeOptions.formats=['markdown'] and onlyMainContent=true when source snippets are not enough and the user needs extracted page context in the search results.",
+  "Use lang, country, or location when the user asks for language-specific, country-specific, or local results.",
+  "Prefer web_contents with Firecrawl scrape options after search when only a small set of known URLs needs full extraction.",
+] as const;
 
 const firecrawlScrapeOptionsSchema = Type.Object(
   {
@@ -563,6 +569,7 @@ export const firecrawlProvider = defineProvider({
   capabilities: {
     search: defineCapability({
       options: firecrawlImplementation.getToolOptionsSchema?.("search"),
+      promptGuidelines: firecrawlSearchPromptGuidelines,
       async execute(input: any, ctx) {
         const { query, maxResults, options } = input;
         return await firecrawlImplementation.search!(

--- a/src/providers/gemini.ts
+++ b/src/providers/gemini.ts
@@ -104,6 +104,13 @@ const geminiSearchOptionsSchema = Type.Object(
   { description: "Gemini search options." },
 );
 
+const geminiSearchPromptGuidelines = [
+  "Use Gemini search when a grounded model should perform web-backed source discovery and return likely sources.",
+  "Change model only when the user requests a specific Gemini model or when project configuration requires it.",
+  "Tune generation_config only for explicit output-control needs; avoid disabling tool use for search tasks.",
+  "Prefer web_contents after Gemini search when selected sources need direct extraction or closer reading.",
+] as const;
+
 const geminiAnswerOptionsSchema = Type.Object(
   {
     model: Type.Optional(
@@ -1124,6 +1131,7 @@ export const geminiProvider = defineProvider({
   capabilities: {
     search: defineCapability({
       options: geminiImplementation.getToolOptionsSchema?.("search"),
+      promptGuidelines: geminiSearchPromptGuidelines,
       async execute(input: any, ctx) {
         const { query, maxResults, options } = input;
         return await geminiImplementation.search!(

--- a/src/providers/linkup.ts
+++ b/src/providers/linkup.ts
@@ -24,6 +24,7 @@ import type {
   Tool,
   ToolOutput,
 } from "../types.js";
+import { defineCapability, defineProvider } from "./definition.js";
 import { literalUnion } from "./schema.js";
 import {
   asJsonObject,
@@ -32,7 +33,6 @@ import {
   trimSnippet,
 } from "./shared.js";
 
-import { defineCapability, defineProvider } from "./definition.js";
 type LinkupSearchOptions = {
   depth?: SearchDepth;
   includeImages?: boolean;
@@ -100,6 +100,13 @@ const linkupSearchOptionsSchema = Type.Object(
   },
   { description: "Linkup search options." },
 );
+
+const linkupSearchPromptGuidelines = [
+  "Use Linkup depth='deep' for exploratory or high-recall source discovery, and 'standard' for quick direct searches.",
+  "Use includeDomains or excludeDomains when the user names source constraints or when limiting the search space improves precision.",
+  "Use fromDate and toDate when the user asks for recent, historical, or bounded-by-date results.",
+  "Enable includeImages only when images are directly useful; otherwise keep search focused on textual source discovery.",
+] as const;
 
 const linkupContentsOptionsSchema = Type.Object(
   {
@@ -625,6 +632,7 @@ export const linkupProvider = defineProvider({
   capabilities: {
     search: defineCapability({
       options: linkupImplementation.getToolOptionsSchema?.("search"),
+      promptGuidelines: linkupSearchPromptGuidelines,
       async execute(input: any, ctx) {
         const { query, maxResults, options } = input;
         return await linkupImplementation.search!(

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -1,5 +1,5 @@
-import { type TObject, Type } from "typebox";
 import OpenAI from "openai";
+import { type TObject, Type } from "typebox";
 import { resolveConfigValue } from "../config-values.js";
 import { executeAsyncResearch } from "../execution-policy.js";
 import type {
@@ -16,9 +16,9 @@ import type {
   Tool,
   ToolOutput,
 } from "../types.js";
+import { defineCapability, defineProvider } from "./definition.js";
 import { getApiKeyStatus, trimSnippet } from "./shared.js";
 
-import { defineCapability, defineProvider } from "./definition.js";
 const DEFAULT_SEARCH_MODEL = "gpt-4.1";
 const DEFAULT_ANSWER_MODEL = "gpt-4.1";
 const DEFAULT_RESEARCH_MODEL = "o4-mini-deep-research";
@@ -40,6 +40,12 @@ const openaiSearchOptionsSchema = Type.Object(
   },
   { description: "OpenAI search options." },
 );
+
+const openaiSearchPromptGuidelines = [
+  "Use OpenAI web search when an LLM-mediated search pass should identify likely sources from the live web.",
+  "Use instructions to constrain source selection, freshness, geography, or output style only when the user explicitly needs that control.",
+  "Prefer web_contents after OpenAI search when the task requires direct inspection of selected primary sources.",
+] as const;
 
 const openaiAnswerOptionsSchema = Type.Object(
   {
@@ -701,6 +707,7 @@ export const openaiProvider = defineProvider({
   capabilities: {
     search: defineCapability({
       options: openaiImplementation.getToolOptionsSchema?.("search"),
+      promptGuidelines: openaiSearchPromptGuidelines,
       async execute(input: any, ctx) {
         const { query, maxResults, options } = input;
         return await openaiImplementation.search!(

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -22,9 +22,9 @@ import {
 const parallelSearchOptionsSchema = Type.Object(
   {
     mode: Type.Optional(
-      literalUnion(["advanced", "basic", "turbo", "agentic", "one-shot"], {
+      literalUnion(["advanced", "basic", "turbo"], {
         description:
-          "Parallel search mode. Use 'advanced' for higher quality, 'basic' for lower latency, or 'turbo' for the fastest responses. Legacy 'agentic' and 'one-shot' aliases are also accepted.",
+          "Parallel search mode. Use 'advanced' for higher quality, 'basic' for lower latency, or 'turbo' for the fastest responses.",
       }),
     ),
   },
@@ -32,8 +32,9 @@ const parallelSearchOptionsSchema = Type.Object(
 );
 
 const parallelSearchPromptGuidelines = [
-  "Use Parallel mode='agentic' for exploratory, ambiguous, or multi-hop source discovery where the provider should plan the search.",
-  "Use Parallel mode='one-shot' for direct factual lookups and simple source finding where low latency is preferred.",
+  "Use Parallel mode='advanced' for exploratory, ambiguous, or multi-hop source discovery where the provider should plan the search.",
+  "Use Parallel mode='basic' for direct factual lookups and simple source finding where low latency is preferred.",
+  "Use Parallel mode='turbo' only when fastest responses matter more than recall or depth.",
   "Prefer web_contents with Parallel extraction when a URL set is already known and the task needs full page content rather than more source discovery.",
 ] as const;
 
@@ -263,10 +264,6 @@ function normalizeParallelSearchMode(
     case "basic":
     case "turbo":
       return value;
-    case "agentic":
-      return "advanced";
-    case "one-shot":
-      return "basic";
     default:
       return undefined;
   }

--- a/src/providers/parallel.ts
+++ b/src/providers/parallel.ts
@@ -31,6 +31,12 @@ const parallelSearchOptionsSchema = Type.Object(
   { description: "Parallel search options." },
 );
 
+const parallelSearchPromptGuidelines = [
+  "Use Parallel mode='agentic' for exploratory, ambiguous, or multi-hop source discovery where the provider should plan the search.",
+  "Use Parallel mode='one-shot' for direct factual lookups and simple source finding where low latency is preferred.",
+  "Prefer web_contents with Parallel extraction when a URL set is already known and the task needs full page content rather than more source discovery.",
+] as const;
+
 const parallelExtractOptionsSchema = Type.Object(
   {
     excerpts: Type.Optional(
@@ -308,6 +314,7 @@ export const parallelProvider = defineProvider({
   capabilities: {
     search: defineCapability({
       options: parallelImplementation.getToolOptionsSchema?.("search"),
+      promptGuidelines: parallelSearchPromptGuidelines,
       async execute(input: any, ctx) {
         const { query, maxResults, options } = input;
         return await parallelImplementation.search!(

--- a/src/providers/perplexity.ts
+++ b/src/providers/perplexity.ts
@@ -51,6 +51,13 @@ const perplexitySearchOptionsSchema = Type.Object(
   { description: "Perplexity search options." },
 );
 
+const perplexitySearchPromptGuidelines = [
+  "Use Perplexity search for concise web result retrieval with recency and domain filters, not for synthesized answers.",
+  "Set search_recency_filter when freshness matters, such as breaking news, recently updated documentation, prices, or current events.",
+  "Set search_domain_filter when the user asks for primary sources, official documentation, or domain-scoped retrieval.",
+  "Use web_answer or web_research with Perplexity when the user wants synthesis rather than a list of candidate sources.",
+] as const;
+
 const perplexityAnswerOptionsSchema = Type.Object(
   {
     model: Type.Optional(
@@ -447,6 +454,7 @@ export const perplexityProvider = defineProvider({
   capabilities: {
     search: defineCapability({
       options: perplexityImplementation.getToolOptionsSchema?.("search"),
+      promptGuidelines: perplexitySearchPromptGuidelines,
       async execute(input: any, ctx) {
         const { query, maxResults, options } = input;
         return await perplexityImplementation.search!(

--- a/src/providers/tavily.ts
+++ b/src/providers/tavily.ts
@@ -74,6 +74,13 @@ const tavilySearchOptionsSchema = Type.Object(
   { description: "Tavily search options." },
 );
 
+const tavilySearchPromptGuidelines = [
+  "Use Tavily topic='news' for recent journalism or current events and topic='finance' for market or company-finance research; otherwise leave topic as general.",
+  "Use searchDepth='advanced' for broader or higher-recall source discovery, and 'basic' for quick direct lookups.",
+  "Set timeRange, days, or country when the user asks for freshness, recency, or geography-specific results.",
+  "Set includeRawContent or includeAnswer only when the search response itself should carry more context; prefer web_contents for selected source inspection.",
+] as const;
+
 const tavilyExtractOptionsSchema = Type.Object(
   {
     extractDepth: Type.Optional(
@@ -284,6 +291,7 @@ export const tavilyProvider = defineProvider({
   capabilities: {
     search: defineCapability({
       options: tavilyImplementation.getToolOptionsSchema?.("search"),
+      promptGuidelines: tavilySearchPromptGuidelines,
       async execute(input: any, ctx) {
         const { query, maxResults, options } = input;
         return await tavilyImplementation.search!(

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -40,7 +40,10 @@ const valyuSearchOptionsSchema = Type.Object(
       Type.String({ description: "Country code to scope search results." }),
     ),
     maxPrice: Type.Optional(
-      Type.Number({ minimum: 0, description: "Maximum search cost in USD." }),
+      Type.Number({
+        minimum: 0,
+        description: "Maximum price per thousand characters (CPM).",
+      }),
     ),
     relevanceThreshold: Type.Optional(
       Type.Number({

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -39,8 +39,94 @@ const valyuSearchOptionsSchema = Type.Object(
     countryCode: Type.Optional(
       Type.String({ description: "Country code to scope search results." }),
     ),
+    maxPrice: Type.Optional(
+      Type.Number({ minimum: 0, description: "Maximum search cost in USD." }),
+    ),
+    relevanceThreshold: Type.Optional(
+      Type.Number({
+        minimum: 0,
+        maximum: 1,
+        description: "Minimum result relevance score.",
+      }),
+    ),
+    includedSources: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Restrict retrieval to these Valyu sources.",
+      }),
+    ),
+    excludeSources: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Exclude these Valyu sources.",
+      }),
+    ),
+    category: Type.Optional(
+      Type.String({ description: "Valyu source category to search." }),
+    ),
+    startDate: Type.Optional(
+      Type.String({ description: "ISO date string for earliest result date." }),
+    ),
+    endDate: Type.Optional(
+      Type.String({ description: "ISO date string for latest result date." }),
+    ),
+    fastMode: Type.Optional(
+      Type.Boolean({
+        description: "Use Valyu fast mode when lower latency is preferred.",
+      }),
+    ),
+    urlOnly: Type.Optional(
+      Type.Boolean({
+        description: "Return URL-focused results with less content.",
+      }),
+    ),
+    instructions: Type.Optional(
+      Type.String({
+        description:
+          "Provider instructions for retrieval and result selection.",
+      }),
+    ),
   },
   { description: "Valyu search options." },
+);
+
+const valyuSearchPromptGuidelines = [
+  "Use Valyu searchType='news' for recent journalism or current events, 'web' for public web results, and 'proprietary' when proprietary Valyu sources are required.",
+  "Use includedSources, excludeSources, category, or source biases from configuration when the user asks for source-specific retrieval.",
+  "Use startDate/endDate and countryCode when the task requires temporal or geographic scoping.",
+  "Set responseLength higher only when search results need richer inline context; otherwise prefer concise results and follow up with web_contents.",
+] as const;
+
+const valyuContentsOptionsSchema = Type.Object(
+  {
+    summary: Type.Optional(
+      Type.Union([Type.Boolean(), Type.String()], {
+        description:
+          "Whether to include a summary, or instructions for the summary.",
+      }),
+    ),
+    extractEffort: Type.Optional(
+      literalUnion(["normal", "high", "auto"], {
+        description:
+          "Extraction effort. Use 'high' for difficult pages and 'normal' for faster extraction.",
+      }),
+    ),
+    responseLength: Type.Optional(
+      literalUnion(["short", "medium", "large", "max"], {
+        description: "Content response length.",
+      }),
+    ),
+    maxPriceDollars: Type.Optional(
+      Type.Number({
+        minimum: 0,
+        description: "Maximum extraction cost in USD.",
+      }),
+    ),
+    screenshot: Type.Optional(
+      Type.Boolean({
+        description: "Include screenshot capture when supported.",
+      }),
+    ),
+  },
+  { description: "Valyu contents options." },
 );
 
 const valyuAnswerOptionsSchema = Type.Object(
@@ -80,6 +166,8 @@ const valyuImplementation = {
     switch (capability) {
       case "search":
         return valyuSearchOptionsSchema;
+      case "contents":
+        return valyuContentsOptionsSchema;
       case "answer":
         return valyuAnswerOptionsSchema;
       case "research":
@@ -150,7 +238,10 @@ const valyuImplementation = {
     options?: Record<string, unknown>,
   ): Promise<ContentsResponse> {
     const client = createClient(config);
-    const response = await client.contents(urls, options as never);
+    const response = await client.contents(urls, {
+      ...(asJsonObject(config.options?.contents) ?? {}),
+      ...(options ?? {}),
+    } as never);
     const finalResponse =
       "jobId" in response
         ? await client.waitForJob(response.jobId, {})
@@ -373,6 +464,7 @@ export const valyuProvider = defineProvider({
   capabilities: {
     search: defineCapability({
       options: valyuImplementation.getToolOptionsSchema?.("search"),
+      promptGuidelines: valyuSearchPromptGuidelines,
       async execute(input: any, ctx) {
         const { query, maxResults, options } = input;
         return await valyuImplementation.search!(

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -452,7 +452,7 @@ export const valyuProvider = defineProvider({
   config: {
     createTemplate: () => valyuImplementation.createTemplate(),
     fields: ["credentials", "baseUrl", "options", "settings"],
-    optionCapabilities: ["search", "answer", "research"],
+    optionCapabilities: ["search", "contents", "answer", "research"],
   },
   getCapabilityStatus: (config, cwd, tool, options) =>
     (valyuImplementation.getCapabilityStatus as any)(

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -98,10 +98,13 @@ const valyuSearchPromptGuidelines = [
 const valyuContentsOptionsSchema = Type.Object(
   {
     summary: Type.Optional(
-      Type.Union([Type.Boolean(), Type.String()], {
-        description:
-          "Whether to include a summary, or instructions for the summary.",
-      }),
+      Type.Union(
+        [Type.Boolean(), Type.String(), Type.Record(Type.String(), Type.Any())],
+        {
+          description:
+            "Whether to include a summary, or instructions for the summary.",
+        },
+      ),
     ),
     extractEffort: Type.Optional(
       literalUnion(["normal", "high", "auto"], {
@@ -110,9 +113,15 @@ const valyuContentsOptionsSchema = Type.Object(
       }),
     ),
     responseLength: Type.Optional(
-      literalUnion(["short", "medium", "large", "max"], {
-        description: "Content response length.",
-      }),
+      Type.Union(
+        [
+          literalUnion(["short", "medium", "large", "max"]),
+          Type.Number({ minimum: 0 }),
+        ],
+        {
+          description: "Content response length.",
+        },
+      ),
     ),
     maxPriceDollars: Type.Optional(
       Type.Number({

--- a/src/types.ts
+++ b/src/types.ts
@@ -250,10 +250,53 @@ export interface SerperOptions {
   search?: SerperSearchOptions;
 }
 
+export interface ValyuSearchOptions extends Record<string, unknown> {
+  searchType?: "all" | "web" | "proprietary" | "news";
+  responseLength?: "short" | "medium" | "large" | "max" | number;
+  countryCode?: string;
+  maxPrice?: number;
+  relevanceThreshold?: number;
+  includedSources?: string[];
+  excludeSources?: string[];
+  sourceBiases?: Record<string, number>;
+  category?: string;
+  startDate?: string;
+  endDate?: string;
+  fastMode?: boolean;
+  urlOnly?: boolean;
+  instructions?: string;
+}
+
+export interface ValyuContentsOptions extends Record<string, unknown> {
+  summary?: boolean | string | object;
+  extractEffort?: "normal" | "high" | "auto";
+  responseLength?: "short" | "medium" | "large" | "max" | number;
+  maxPriceDollars?: number;
+  screenshot?: boolean;
+}
+
+export interface ValyuAnswerOptions extends Record<string, unknown> {
+  responseLength?: "short" | "medium" | "large" | "max" | number;
+  countryCode?: string;
+  searchType?: "all" | "web" | "proprietary" | "news";
+  dataMaxPrice?: number;
+  includedSources?: string[];
+  excludedSources?: string[];
+  startDate?: string;
+  endDate?: string;
+  fastMode?: boolean;
+}
+
+export interface ValyuResearchOptions extends Record<string, unknown> {
+  responseLength?: "short" | "medium" | "large" | "max";
+  countryCode?: string;
+}
+
 export interface ValyuOptions {
-  search?: Record<string, unknown>;
-  answer?: Record<string, unknown>;
-  research?: Record<string, unknown>;
+  search?: ValyuSearchOptions;
+  contents?: ValyuContentsOptions;
+  answer?: ValyuAnswerOptions;
+  research?: ValyuResearchOptions;
 }
 
 export interface CustomCommandConfig {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -295,6 +295,9 @@ describe("config parsing", () => {
               answer: {
                 responseLength: "medium",
               },
+              contents: {
+                responseLength: "medium",
+              },
               research: {
                 responseLength: "large",
               },
@@ -312,6 +315,9 @@ describe("config parsing", () => {
           searchType: "all",
         },
         answer: {
+          responseLength: "medium",
+        },
+        contents: {
           responseLength: "medium",
         },
         research: {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -564,7 +564,7 @@ describe("config parsing", () => {
       credentials: { api: "PARALLEL_API_KEY" },
       options: {
         search: {
-          mode: "one-shot",
+          mode: "basic",
         },
       },
     };
@@ -648,7 +648,7 @@ describe("config parsing", () => {
     expect(loaded.providers?.perplexity?.options?.research?.model).toBe(
       "sonar-deep-research",
     );
-    expect(loaded.providers?.parallel?.options?.search?.mode).toBe("one-shot");
+    expect(loaded.providers?.parallel?.options?.search?.mode).toBe("basic");
     expect(loaded.providers?.tavily?.options?.search?.topic).toBe("news");
     expect(loaded.providers?.tavily?.options?.extract?.format).toBe("text");
     expect(loaded.settings?.search).toEqual({

--- a/test/contents-providers.test.ts
+++ b/test/contents-providers.test.ts
@@ -219,14 +219,14 @@ describe("contents providers", () => {
     });
   });
 
-  it("maps Parallel search to the v1 search API and legacy modes", async () => {
+  it("maps Parallel search to the v1 search API", async () => {
     const { parallelProvider } = await import("../src/providers/parallel.js");
     const provider = providerHarness(parallelProvider);
     const config = provider.createTemplate();
     config.credentials = { api: "literal-key" };
     config.options = {
       search: {
-        mode: "agentic",
+        mode: "advanced",
       },
     };
 
@@ -246,7 +246,7 @@ describe("contents providers", () => {
       config,
       { cwd: process.cwd() },
       {
-        mode: "one-shot",
+        mode: "basic",
       },
     );
 

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -39,6 +39,7 @@ beforeEach(() => {
   delete process.env.BRAVE_SEARCH_API_KEY;
   delete process.env.CODEX_API_KEY;
   delete process.env.EXA_API_KEY;
+  delete process.env.FIRECRAWL_API_KEY;
   delete process.env.PERPLEXITY_API_KEY;
   delete process.env.GOOGLE_API_KEY;
   delete process.env.LINKUP_API_KEY;
@@ -53,6 +54,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.BRAVE_SEARCH_API_KEY;
   delete process.env.EXA_API_KEY;
+  delete process.env.FIRECRAWL_API_KEY;
   delete process.env.CODEX_API_KEY;
   delete process.env.PERPLEXITY_API_KEY;
   delete process.env.LINKUP_API_KEY;
@@ -60,6 +62,9 @@ afterEach(() => {
   delete process.env.OPENAI_API_KEY;
   delete process.env.SERPER_API_KEY;
   delete process.env.TAVILY_API_KEY;
+  delete process.env.GOOGLE_API_KEY;
+  delete process.env.PARALLEL_API_KEY;
+  delete process.env.VALYU_API_KEY;
   execFileSyncMock.mockReset();
   if (originalHome === undefined) {
     delete process.env.HOME;
@@ -237,6 +242,73 @@ describe("managed tool availability", () => {
         expect.stringContaining("webpage mode"),
       ]),
     );
+  });
+
+  it("adds provider-specific search prompt guidelines across typed providers", async () => {
+    const cases: Array<{
+      provider: string;
+      env?: string;
+      expected: string;
+    }> = [
+      { provider: "claude", expected: "Claude search" },
+      { provider: "codex", expected: "Codex search" },
+      { provider: "exa", env: "EXA_API_KEY", expected: "Exa's neural/auto" },
+      {
+        provider: "firecrawl",
+        env: "FIRECRAWL_API_KEY",
+        expected: "Firecrawl search",
+      },
+      { provider: "gemini", env: "GOOGLE_API_KEY", expected: "Gemini search" },
+      {
+        provider: "linkup",
+        env: "LINKUP_API_KEY",
+        expected: "Linkup depth='deep'",
+      },
+      {
+        provider: "openai",
+        env: "OPENAI_API_KEY",
+        expected: "OpenAI web search",
+      },
+      {
+        provider: "parallel",
+        env: "PARALLEL_API_KEY",
+        expected: "Parallel mode='agentic'",
+      },
+      {
+        provider: "perplexity",
+        env: "PERPLEXITY_API_KEY",
+        expected: "Perplexity search",
+      },
+      {
+        provider: "tavily",
+        env: "TAVILY_API_KEY",
+        expected: "Tavily topic='news'",
+      },
+      {
+        provider: "valyu",
+        env: "VALYU_API_KEY",
+        expected: "Valyu searchType='news'",
+      },
+    ];
+
+    for (const { provider, env, expected } of cases) {
+      if (env) {
+        process.env[env] = "test-key";
+      }
+      writeConfig({
+        tools: {
+          search: provider as never,
+        },
+        providers: {
+          [provider]: env ? { credentials: { api: env } } : {},
+        },
+      });
+
+      const tools = await captureRegisteredTools();
+      const webSearch = tools.find((tool) => tool.name === "web_search");
+      expect(webSearch?.promptGuidelines?.join("\n")).toContain(expected);
+      expect(webSearch?.parameters?.properties).toHaveProperty("options");
+    }
   });
 
   it("registers provider-bound search schemas from configuration", async () => {

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -311,6 +311,37 @@ describe("managed tool availability", () => {
     }
   });
 
+  it("registers Valyu contents schema with structured summaries and numeric response length", async () => {
+    process.env.VALYU_API_KEY = "test-key";
+    writeConfig({
+      tools: {
+        contents: "valyu",
+      },
+      providers: {
+        valyu: {
+          credentials: { api: "VALYU_API_KEY" },
+        },
+      },
+    });
+
+    const tools = await captureRegisteredTools();
+    const webContents = tools.find((tool) => tool.name === "web_contents");
+    const options = webContents?.parameters?.properties?.options as {
+      properties?: Record<string, { anyOf?: Array<{ type?: string }> }>;
+    };
+
+    expect(options.properties?.summary?.anyOf).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "boolean" }),
+        expect.objectContaining({ type: "string" }),
+        expect.objectContaining({ type: "object" }),
+      ]),
+    );
+    expect(options.properties?.responseLength?.anyOf).toEqual(
+      expect.arrayContaining([expect.objectContaining({ type: "number" })]),
+    );
+  });
+
   it("registers provider-bound search schemas from configuration", async () => {
     process.env.OLLAMA_API_KEY = "test-key";
     writeConfig({

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -272,7 +272,7 @@ describe("managed tool availability", () => {
       {
         provider: "parallel",
         env: "PARALLEL_API_KEY",
-        expected: "Parallel mode='agentic'",
+        expected: "Parallel mode='advanced'",
       },
       {
         provider: "perplexity",


### PR DESCRIPTION
## 🔍 Problem

- Provider-specific search guidance exists in code but is not surfaced consistently to users.
- Tool descriptions do not make provider limitations, options, and best-fit workflows visible enough.

## 🛠️ Solution

- Add provider-specific guidance fields and expose them in tool availability metadata.
- Expand search guidance across the supported providers, including Valyu-specific category and domain behavior.
- Document the provider-specific guidance in the README and cover it with tests.

## 💬 Review

- Check whether the guidance is concise enough for tool descriptions.
- Validate the Valyu-specific option descriptions and category examples.
