### PR TITLE
Add live provider test contracts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,17 @@ name: CI
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      live_api_providers:
+        description: "Comma-separated providers for the live API job; blank means all API-backed providers"
+        required: false
+        default: ""
+      live_api_capabilities:
+        description: "Comma-separated capabilities for the live API job"
+        required: false
+        default: "search,contents,answer"
+  schedule:
+    - cron: "23 4 * * 1"
 
 permissions:
   contents: read
@@ -44,4 +55,44 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm test
+        run: npm run test:ci
+
+  live-api:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      LIVE_API_TESTS: "1"
+      LIVE_API_PROVIDERS: ${{ github.event_name == 'workflow_dispatch' && inputs.live_api_providers || '' }}
+      LIVE_API_CAPABILITIES: ${{ github.event_name == 'workflow_dispatch' && inputs.live_api_capabilities || 'search,contents,answer' }}
+      BRAVE_SEARCH_API_KEY: ${{ secrets.BRAVE_SEARCH_API_KEY }}
+      BRAVE_ANSWERS_API_KEY: ${{ secrets.BRAVE_ANSWERS_API_KEY }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      EXA_API_KEY: ${{ secrets.EXA_API_KEY }}
+      FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      LINKUP_API_KEY: ${{ secrets.LINKUP_API_KEY }}
+      OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      PARALLEL_API_KEY: ${{ secrets.PARALLEL_API_KEY }}
+      PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+      SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
+      TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+      VALYU_API_KEY: ${{ secrets.VALYU_API_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run live API tests
+        run: npm run test:live

--- a/README.md
+++ b/README.md
@@ -83,6 +83,63 @@ command using a JSON stdin/stdout contract.
 See [`example-config.json`](example-config.json) for the minimal default
 configuration.
 
+## 🧪 Testing
+
+The default test suite is deterministic and does not use the network or provider
+credentials:
+
+```sh
+npm test
+```
+
+Live provider coverage is opt-in and uses real API keys from environment
+variables. It runs the public routing and execution path for the selected
+providers, then asserts stable contracts such as provider readiness, result
+shape, non-empty useful content, and normalized failures. It intentionally does
+not snapshot exact rankings, generated text, timestamps, or full provider
+responses.
+
+```sh
+npm run test:live
+```
+
+`test:live` sets `LIVE_API_TESTS=1` and fails fast when any selected contract is
+missing its required environment variable. By default it runs `search`,
+`contents`, and `answer` contracts for all API-backed providers. Research
+contracts are slower and may cost more, so run them explicitly:
+
+```sh
+LIVE_API_CAPABILITIES=research npm run test:live
+```
+
+Use comma-separated filters to run a smaller subset:
+
+```sh
+LIVE_API_PROVIDERS=openai,tavily LIVE_API_CAPABILITIES=search,contents npm run test:live
+```
+
+GitHub Actions reads the same names from repository secrets:
+
+| Provider    | Required secret names                                      |
+| ----------- | ---------------------------------------------------------- |
+| Brave       | `BRAVE_SEARCH_API_KEY`, `BRAVE_ANSWERS_API_KEY`            |
+| Cloudflare  | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`            |
+| Exa         | `EXA_API_KEY`                                              |
+| Firecrawl   | `FIRECRAWL_API_KEY`                                        |
+| Gemini      | `GOOGLE_API_KEY`                                           |
+| Linkup      | `LINKUP_API_KEY`                                           |
+| Ollama      | `OLLAMA_API_KEY`                                           |
+| OpenAI      | `OPENAI_API_KEY`                                           |
+| Parallel    | `PARALLEL_API_KEY`                                         |
+| Perplexity  | `PERPLEXITY_API_KEY`                                       |
+| Serper      | `SERPER_API_KEY`                                           |
+| Tavily      | `TAVILY_API_KEY`                                           |
+| Valyu       | `VALYU_API_KEY`                                            |
+
+The live API workflow is separate from the normal CI job, runs on manual
+dispatch and a weekly schedule, and skips forked pull requests because GitHub
+does not expose repository secrets to them.
+
 ### Tools
 
 Each managed tool maps to one provider id under the top-level `tools` key.

--- a/changelog/unreleased/secret-backed-live-provider-tests.md
+++ b/changelog/unreleased/secret-backed-live-provider-tests.md
@@ -1,0 +1,18 @@
+---
+title: Secret-backed live provider tests
+type: feature
+authors:
+  - mavam
+  - codex
+prs:
+  - 33
+created: 2026-06-13T09:39:13.275145Z
+---
+
+Maintainers can now verify API-backed providers with a documented, opt-in live test workflow:
+
+```sh
+npm run test:live
+```
+
+The default `npm test` remains deterministic and credential-free. Live runs use provider credentials from environment variables or GitHub Secrets, and can be filtered with `LIVE_API_PROVIDERS` and `LIVE_API_CAPABILITIES`.

--- a/package.json
+++ b/package.json
@@ -61,8 +61,11 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "smoke:live": "npm run build && node scripts/live-smoke.mjs",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "test": "npm run test:unit",
+    "test:ci": "npm run test:unit",
+    "test:live": "LIVE_API_TESTS=1 vitest run --dir test/live --no-file-parallelism --maxWorkers=1",
+    "test:unit": "vitest run --exclude 'test/live/**'",
+    "test:watch": "vitest --exclude 'test/live/**'"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.177",

--- a/test/live-api-contracts.test.ts
+++ b/test/live-api-contracts.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { PROVIDERS_BY_ID } from "../src/providers/index.js";
+import { TOOLS, type Tool } from "../src/types.js";
+import {
+  API_PROVIDER_IDS,
+  DEFAULT_LIVE_API_CAPABILITIES,
+  getMissingLiveApiSecrets,
+  LIVE_API_CONTRACTS,
+  selectLiveApiContracts,
+} from "./live-api-contracts.js";
+
+describe("live API contract matrix", () => {
+  it("covers every API-backed provider capability", () => {
+    const expected = API_PROVIDER_IDS.flatMap((providerId) =>
+      TOOLS.filter((capability) => {
+        const capabilities = PROVIDERS_BY_ID[providerId]
+          .capabilities as Partial<Record<Tool, unknown>>;
+        return capabilities[capability] !== undefined;
+      }).map((capability) => `${providerId}/${capability}`),
+    ).sort();
+
+    const actual = LIVE_API_CONTRACTS.map(
+      (contract) => `${contract.provider}/${contract.capability}`,
+    ).sort();
+
+    expect(actual).toEqual(expected);
+  });
+
+  it("selects quick live coverage by default", () => {
+    const selected = selectLiveApiContracts({});
+    const capabilities = new Set(
+      selected.map((contract) => contract.capability),
+    );
+
+    expect([...capabilities].sort()).toEqual(
+      [...DEFAULT_LIVE_API_CAPABILITIES].sort(),
+    );
+    expect(capabilities.has("research")).toBe(false);
+  });
+
+  it("can select research coverage explicitly", () => {
+    const selected = selectLiveApiContracts({
+      LIVE_API_INCLUDE_RESEARCH: "1",
+    });
+    const capabilities = new Set(
+      selected.map((contract) => contract.capability),
+    );
+
+    expect(capabilities.has("research")).toBe(true);
+  });
+
+  it("requires only the secrets used by the selected contracts", () => {
+    const selected = selectLiveApiContracts({
+      LIVE_API_PROVIDERS: "brave",
+      LIVE_API_CAPABILITIES: "search",
+    });
+
+    expect(getMissingLiveApiSecrets(selected, {})).toEqual([
+      "BRAVE_SEARCH_API_KEY",
+    ]);
+  });
+
+  it("rejects unknown provider and capability filters", () => {
+    expect(() =>
+      selectLiveApiContracts({ LIVE_API_PROVIDERS: "unknown" }),
+    ).toThrow("Unknown LIVE_API_PROVIDERS value(s): unknown.");
+
+    expect(() =>
+      selectLiveApiContracts({
+        LIVE_API_CAPABILITIES: "search,unknown",
+      }),
+    ).toThrow("Unknown LIVE_API_CAPABILITIES value(s): unknown.");
+  });
+});

--- a/test/live-api-contracts.ts
+++ b/test/live-api-contracts.ts
@@ -1,0 +1,393 @@
+import { TOOLS, type ProviderId, type Tool } from "../src/types.js";
+
+export const API_PROVIDER_IDS = [
+  "brave",
+  "cloudflare",
+  "exa",
+  "firecrawl",
+  "gemini",
+  "linkup",
+  "ollama",
+  "openai",
+  "parallel",
+  "perplexity",
+  "serper",
+  "tavily",
+  "valyu",
+] as const satisfies readonly ProviderId[];
+
+export type ApiProviderId = (typeof API_PROVIDER_IDS)[number];
+
+export interface LiveApiContract {
+  provider: ApiProviderId;
+  capability: Tool;
+  secretEnvVars: readonly string[];
+  query?: string;
+  input?: string;
+  urls?: readonly string[];
+  maxResults?: number;
+  options?: Record<string, unknown>;
+  timeoutMs: number;
+}
+
+export const DEFAULT_LIVE_API_CAPABILITIES = [
+  "search",
+  "contents",
+  "answer",
+] as const satisfies readonly Tool[];
+
+const SEARCH_QUERY = "IANA Example Domain example.com";
+const ANSWER_QUERY =
+  "What is the purpose of example.com according to IANA? Answer in one sentence.";
+const RESEARCH_INPUT =
+  "In two concise sentences, explain what example.com is used for and cite the source.";
+const CONTENT_URLS = ["https://example.com/"] as const;
+
+export const LIVE_API_CONTRACTS = [
+  {
+    provider: "brave",
+    capability: "search",
+    secretEnvVars: ["BRAVE_SEARCH_API_KEY"],
+    query: SEARCH_QUERY,
+    maxResults: 2,
+    timeoutMs: 60_000,
+  },
+  {
+    provider: "brave",
+    capability: "answer",
+    secretEnvVars: ["BRAVE_ANSWERS_API_KEY"],
+    query: ANSWER_QUERY,
+    timeoutMs: 120_000,
+  },
+  {
+    provider: "brave",
+    capability: "research",
+    secretEnvVars: ["BRAVE_ANSWERS_API_KEY"],
+    input: RESEARCH_INPUT,
+    timeoutMs: 240_000,
+  },
+  {
+    provider: "cloudflare",
+    capability: "contents",
+    secretEnvVars: ["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID"],
+    urls: CONTENT_URLS,
+    timeoutMs: 120_000,
+  },
+  {
+    provider: "exa",
+    capability: "search",
+    secretEnvVars: ["EXA_API_KEY"],
+    query: SEARCH_QUERY,
+    maxResults: 2,
+    options: { contents: { text: false } },
+    timeoutMs: 60_000,
+  },
+  {
+    provider: "exa",
+    capability: "contents",
+    secretEnvVars: ["EXA_API_KEY"],
+    urls: CONTENT_URLS,
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "exa",
+    capability: "answer",
+    secretEnvVars: ["EXA_API_KEY"],
+    query: ANSWER_QUERY,
+    timeoutMs: 120_000,
+  },
+  {
+    provider: "exa",
+    capability: "research",
+    secretEnvVars: ["EXA_API_KEY"],
+    input: RESEARCH_INPUT,
+    timeoutMs: 240_000,
+  },
+  {
+    provider: "firecrawl",
+    capability: "search",
+    secretEnvVars: ["FIRECRAWL_API_KEY"],
+    query: SEARCH_QUERY,
+    maxResults: 2,
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "firecrawl",
+    capability: "contents",
+    secretEnvVars: ["FIRECRAWL_API_KEY"],
+    urls: CONTENT_URLS,
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "firecrawl",
+    capability: "answer",
+    secretEnvVars: ["FIRECRAWL_API_KEY"],
+    query: ANSWER_QUERY,
+    options: { url: CONTENT_URLS[0], onlyMainContent: true },
+    timeoutMs: 120_000,
+  },
+  {
+    provider: "gemini",
+    capability: "search",
+    secretEnvVars: ["GOOGLE_API_KEY"],
+    query: SEARCH_QUERY,
+    maxResults: 2,
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "gemini",
+    capability: "answer",
+    secretEnvVars: ["GOOGLE_API_KEY"],
+    query: ANSWER_QUERY,
+    options: { config: { maxOutputTokens: 256 } },
+    timeoutMs: 120_000,
+  },
+  {
+    provider: "gemini",
+    capability: "research",
+    secretEnvVars: ["GOOGLE_API_KEY"],
+    input: RESEARCH_INPUT,
+    timeoutMs: 360_000,
+  },
+  {
+    provider: "linkup",
+    capability: "search",
+    secretEnvVars: ["LINKUP_API_KEY"],
+    query: SEARCH_QUERY,
+    maxResults: 2,
+    options: { depth: "standard" },
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "linkup",
+    capability: "contents",
+    secretEnvVars: ["LINKUP_API_KEY"],
+    urls: CONTENT_URLS,
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "linkup",
+    capability: "research",
+    secretEnvVars: ["LINKUP_API_KEY"],
+    input: RESEARCH_INPUT,
+    options: { mode: "answer", reasoningDepth: "S" },
+    timeoutMs: 240_000,
+  },
+  {
+    provider: "ollama",
+    capability: "search",
+    secretEnvVars: ["OLLAMA_API_KEY"],
+    query: SEARCH_QUERY,
+    maxResults: 2,
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "ollama",
+    capability: "contents",
+    secretEnvVars: ["OLLAMA_API_KEY"],
+    urls: CONTENT_URLS,
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "openai",
+    capability: "search",
+    secretEnvVars: ["OPENAI_API_KEY"],
+    query: SEARCH_QUERY,
+    maxResults: 2,
+    options: {
+      instructions: "Return concise source records for a test assertion.",
+    },
+    timeoutMs: 120_000,
+  },
+  {
+    provider: "openai",
+    capability: "answer",
+    secretEnvVars: ["OPENAI_API_KEY"],
+    query: ANSWER_QUERY,
+    options: { instructions: "Keep the answer concise." },
+    timeoutMs: 120_000,
+  },
+  {
+    provider: "openai",
+    capability: "research",
+    secretEnvVars: ["OPENAI_API_KEY"],
+    input: RESEARCH_INPUT,
+    options: {
+      instructions: "Keep the report to two sentences.",
+      max_tool_calls: 2,
+    },
+    timeoutMs: 360_000,
+  },
+  {
+    provider: "parallel",
+    capability: "search",
+    secretEnvVars: ["PARALLEL_API_KEY"],
+    query: SEARCH_QUERY,
+    maxResults: 2,
+    options: { mode: "basic" },
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "parallel",
+    capability: "contents",
+    secretEnvVars: ["PARALLEL_API_KEY"],
+    urls: CONTENT_URLS,
+    options: { full_content: true, excerpts: false },
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "perplexity",
+    capability: "search",
+    secretEnvVars: ["PERPLEXITY_API_KEY"],
+    query: SEARCH_QUERY,
+    maxResults: 2,
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "perplexity",
+    capability: "answer",
+    secretEnvVars: ["PERPLEXITY_API_KEY"],
+    query: ANSWER_QUERY,
+    options: { model: "sonar" },
+    timeoutMs: 120_000,
+  },
+  {
+    provider: "perplexity",
+    capability: "research",
+    secretEnvVars: ["PERPLEXITY_API_KEY"],
+    input: RESEARCH_INPUT,
+    options: { model: "sonar-deep-research" },
+    timeoutMs: 360_000,
+  },
+  {
+    provider: "serper",
+    capability: "search",
+    secretEnvVars: ["SERPER_API_KEY"],
+    query: SEARCH_QUERY,
+    maxResults: 2,
+    options: { mode: "search", gl: "us", hl: "en" },
+    timeoutMs: 60_000,
+  },
+  {
+    provider: "tavily",
+    capability: "search",
+    secretEnvVars: ["TAVILY_API_KEY"],
+    query: SEARCH_QUERY,
+    maxResults: 2,
+    options: { includeAnswer: false, includeRawContent: false },
+    timeoutMs: 60_000,
+  },
+  {
+    provider: "tavily",
+    capability: "contents",
+    secretEnvVars: ["TAVILY_API_KEY"],
+    urls: CONTENT_URLS,
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "valyu",
+    capability: "search",
+    secretEnvVars: ["VALYU_API_KEY"],
+    query: SEARCH_QUERY,
+    maxResults: 2,
+    options: { searchType: "web", responseLength: "short" },
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "valyu",
+    capability: "contents",
+    secretEnvVars: ["VALYU_API_KEY"],
+    urls: CONTENT_URLS,
+    timeoutMs: 90_000,
+  },
+  {
+    provider: "valyu",
+    capability: "answer",
+    secretEnvVars: ["VALYU_API_KEY"],
+    query: ANSWER_QUERY,
+    options: { responseLength: "short" },
+    timeoutMs: 120_000,
+  },
+  {
+    provider: "valyu",
+    capability: "research",
+    secretEnvVars: ["VALYU_API_KEY"],
+    input: RESEARCH_INPUT,
+    options: { responseLength: "short" },
+    timeoutMs: 240_000,
+  },
+] as const satisfies readonly LiveApiContract[];
+
+export function selectLiveApiContracts(
+  env: NodeJS.ProcessEnv = process.env,
+): LiveApiContract[] {
+  const providers = parseProviderFilter(env);
+  const capabilities = parseCapabilityFilter(env);
+
+  return LIVE_API_CONTRACTS.filter(
+    (contract) =>
+      providers.includes(contract.provider) &&
+      capabilities.includes(contract.capability),
+  );
+}
+
+export function getMissingLiveApiSecrets(
+  contracts: readonly LiveApiContract[],
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  const secretNames = new Set(
+    contracts.flatMap((contract) => contract.secretEnvVars),
+  );
+  return [...secretNames].filter((name) => !env[name]?.trim()).sort();
+}
+
+function parseProviderFilter(env: NodeJS.ProcessEnv): ApiProviderId[] {
+  const raw = parseCsv(env.LIVE_API_PROVIDERS);
+  if (raw.length === 0) {
+    return [...API_PROVIDER_IDS];
+  }
+
+  const unknown = raw.filter((value) => !isApiProviderId(value));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown LIVE_API_PROVIDERS value(s): ${unknown.join(", ")}.`,
+    );
+  }
+
+  return raw as ApiProviderId[];
+}
+
+function parseCapabilityFilter(env: NodeJS.ProcessEnv): Tool[] {
+  const raw = parseCsv(env.LIVE_API_CAPABILITIES);
+  if (raw.length === 0) {
+    return env.LIVE_API_INCLUDE_RESEARCH === "1"
+      ? [...TOOLS]
+      : [...DEFAULT_LIVE_API_CAPABILITIES];
+  }
+
+  const unknown = raw.filter((value) => !isTool(value));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown LIVE_API_CAPABILITIES value(s): ${unknown.join(", ")}.`,
+    );
+  }
+
+  return raw as Tool[];
+}
+
+function parseCsv(value: string | undefined): string[] {
+  return (
+    value
+      ?.split(",")
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0) ?? []
+  );
+}
+
+function isApiProviderId(value: string): value is ApiProviderId {
+  return (API_PROVIDER_IDS as readonly string[]).includes(value);
+}
+
+function isTool(value: string): value is Tool {
+  return (TOOLS as readonly string[]).includes(value);
+}

--- a/test/live/api-live.test.ts
+++ b/test/live/api-live.test.ts
@@ -1,0 +1,154 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { __test__ } from "../../src/index.js";
+import type { ContentsResponse } from "../../src/contents.js";
+import { PROVIDERS_BY_ID } from "../../src/providers/index.js";
+import type {
+  ProviderConfig,
+  SearchResponse,
+  ToolOutput,
+  WebProviders,
+} from "../../src/types.js";
+import {
+  getMissingLiveApiSecrets,
+  type LiveApiContract,
+  selectLiveApiContracts,
+} from "../live-api-contracts.js";
+
+const isLiveApiEnabled = process.env.LIVE_API_TESTS === "1";
+const describeLive = isLiveApiEnabled ? describe.sequential : describe.skip;
+const selectedContracts = isLiveApiEnabled ? selectLiveApiContracts() : [];
+
+describeLive("live API provider contracts", () => {
+  beforeAll(() => {
+    if (selectedContracts.length === 0) {
+      throw new Error(
+        "LIVE_API_TESTS=1 but no live API contracts were selected. Check LIVE_API_PROVIDERS and LIVE_API_CAPABILITIES.",
+      );
+    }
+
+    const missingSecrets = getMissingLiveApiSecrets(selectedContracts);
+    if (missingSecrets.length > 0) {
+      throw new Error(
+        [
+          "LIVE_API_TESTS=1 selected live API contracts but required environment variables are missing:",
+          missingSecrets.join(", "),
+          "Set LIVE_API_PROVIDERS or LIVE_API_CAPABILITIES to run a smaller subset.",
+        ].join(" "),
+      );
+    }
+  });
+
+  for (const contract of selectedContracts) {
+    it(
+      `${contract.provider}/${contract.capability} satisfies the live contract`,
+      async () => {
+        const config = buildLiveConfig(contract);
+        const status = __test__.getProviderStatusForTool(
+          config,
+          process.cwd(),
+          contract.provider,
+          contract.capability,
+        );
+
+        expect(status.state).toBe("ready");
+
+        const result = await __test__.executeRawProviderRequest({
+          capability: contract.capability,
+          config,
+          explicitProvider: contract.provider,
+          ctx: { cwd: process.cwd() },
+          signal: AbortSignal.timeout(contract.timeoutMs),
+          options: contract.options,
+          maxResults: contract.maxResults,
+          urls: contract.urls ? [...contract.urls] : undefined,
+          query: contract.query,
+          input: contract.input,
+        });
+
+        assertLiveResult(contract, result);
+      },
+      contract.timeoutMs + 5_000,
+    );
+  }
+});
+
+function buildLiveConfig(contract: LiveApiContract): WebProviders {
+  const providerConfig = PROVIDERS_BY_ID[
+    contract.provider
+  ].config.createTemplate() as ProviderConfig;
+
+  return {
+    tools: {
+      [contract.capability]: contract.provider,
+    } as WebProviders["tools"],
+    settings: {
+      requestTimeoutMs: Math.min(contract.timeoutMs, 90_000),
+      retryCount: 0,
+      retryDelayMs: 500,
+      researchTimeoutMs: contract.timeoutMs,
+    },
+    providers: {
+      [contract.provider]: providerConfig,
+    } as WebProviders["providers"],
+  };
+}
+
+function assertLiveResult(
+  contract: LiveApiContract,
+  result: SearchResponse | ContentsResponse | ToolOutput,
+): void {
+  expect(result.provider).toBe(contract.provider);
+
+  switch (contract.capability) {
+    case "search":
+      assertSearchResult(contract, result as SearchResponse);
+      return;
+    case "contents":
+      assertContentsResult(contract, result as ContentsResponse);
+      return;
+    case "answer":
+    case "research":
+      assertToolOutput(contract, result as ToolOutput);
+      return;
+  }
+}
+
+function assertSearchResult(
+  contract: LiveApiContract,
+  result: SearchResponse,
+): void {
+  expect(result.results.length).toBeGreaterThan(0);
+  expect(result.results.length).toBeLessThanOrEqual(contract.maxResults ?? 2);
+
+  for (const item of result.results) {
+    expect(isNonEmptyString(item.url)).toBe(true);
+    expect(() => new URL(item.url)).not.toThrow();
+    expect(isNonEmptyString(item.title) || isNonEmptyString(item.snippet)).toBe(
+      true,
+    );
+  }
+}
+
+function assertContentsResult(
+  contract: LiveApiContract,
+  result: ContentsResponse,
+): void {
+  expect(result.answers.length).toBe(contract.urls?.length ?? 0);
+
+  const readableAnswers = result.answers.filter(
+    (answer) =>
+      isNonEmptyString(answer.content) || isNonEmptyString(answer.summary),
+  );
+  expect(readableAnswers.length).toBeGreaterThan(0);
+}
+
+function assertToolOutput(contract: LiveApiContract, result: ToolOutput): void {
+  const text = result.text.trim();
+  expect(text.length).toBeGreaterThan(
+    contract.capability === "research" ? 40 : 20,
+  );
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}


### PR DESCRIPTION
## 🔍 Problem

- Provider tests covered mocked behavior, but there was no CI path for validating real API-backed providers with GitHub Secrets.
- The default test suite still needs to stay fast, deterministic, and credential-free.

## 🛠️ Solution

- Add opt-in live API contracts for every API-backed provider capability, using env-var credentials and stable shape/content assertions.
- Split package scripts so `npm test` stays offline and `npm run test:live` runs selected live contracts sequentially.
- Add a separate secret-backed GitHub Actions live API job for manual, scheduled, and same-repository PR runs.
- Document local and GitHub Secret-backed live testing, including provider and capability filters.

## 💬 Review

- Focus on the provider/capability contract matrix, the missing-secret failure mode, and the CI trigger/fork behavior.
- The live tests intentionally avoid exact-output snapshots so provider ranking and generated text drift do not cause brittle failures.