### PR TITLE
Update provider SDK surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,10 +317,12 @@ scope, or account ID is usually wrong.
 - SDK: `exa-js`
 - Supports `web_search`, `web_contents`, `web_answer`, and `web_research`
 - `web_research` is exposed through pi's async research workflow
-- Neural, keyword, hybrid, and deep-research search modes
+- Neural, keyword, hybrid, and deep-search search modes
 - Inline text-content extraction on search results
-- Exposes search options such as `category`, `type`, date filters,
-  `includeDomains`, `excludeDomains`, `userLocation`, and `contents`
+- Exposes search options such as `category`, `type`, crawl and publish date
+  filters, `includeDomains`, `excludeDomains`, `includeText`, `excludeText`,
+  `userLocation`, `additionalQueries`, `systemPrompt`, and richer `contents`
+  controls such as `livecrawl`, `maxAgeHours`, `subpages`, and `extras`
 - Persisted Exa defaults are scoped under `providers.exa.options.search`
 - `web_contents`, `web_answer`, and `web_research` currently use fixed provider behavior with no extra per-call provider options
 
@@ -337,11 +339,15 @@ scope, or account ID is usually wrong.
   set `options.url` in the `web_answer` call or
   `providers.firecrawl.options.answer.url` as a default
 - Exposes search options such as `lang`, `country`, `sources`, `categories`,
-  `location`, `timeout`, and `scrapeOptions`
+  domain filters, `tbs`, `location`, `timeout`, and `scrapeOptions`
 - Exposes contents options such as `formats`, `onlyMainContent`, `includeTags`,
-  `excludeTags`, `waitFor`, `headers`, `location`, `mobile`, and `proxy`
+  `excludeTags`, `waitFor`, `timeout`, `headers`, `location`, `mobile`,
+  `proxy`, `fastMode`, `blockAds`, `removeBase64Images`, `redactPII`, and
+  cache controls
 - Exposes answer options `url`, `onlyMainContent`, `includeTags`,
-  `excludeTags`, `waitFor`, `headers`, `location`, `mobile`, and `proxy`
+  `excludeTags`, `waitFor`, `timeout`, `headers`, `location`, `mobile`,
+  `proxy`, `fastMode`, `blockAds`, `removeBase64Images`, `redactPII`, and
+  cache controls
 - Firecrawl charges 5 credits per page for the `question` format
 - Optional `baseUrl` overrides are supported for self-hosted Firecrawl
   instances, proxies, and testing. API keys are required for Firecrawl Cloud,
@@ -426,10 +432,12 @@ Minimal config:
 - Supports `web_search`, `web_answer`, and `web_research`
 - Uses the Responses API for structured web search, grounded answers, and
   deep-research runs
-- Always enables OpenAI's built-in `web_search_preview` tool for search,
-  answer, and research calls
-- Exposes `model` and `instructions` for `web_search` and `web_answer`
-- Exposes `model`, `instructions`, and `max_tool_calls` for `web_research`
+- Enables OpenAI's built-in `web_search` tool for search, answer, and research
+  calls
+- Exposes `model`, `instructions`, `searchContextSize`, `allowedDomains`, and
+  `userLocation` for `web_search` and `web_answer`
+- Exposes `model`, `instructions`, `max_tool_calls`, `searchContextSize`,
+  `allowedDomains`, and `userLocation` for `web_research`
 - Good fit when you want official OpenAI web-grounded search, answers, and deep
   research behind pi's managed tool abstractions
 
@@ -563,11 +571,16 @@ Minimal config:
 - `web_research` is exposed through pi's async research workflow
 - Web, proprietary, and news search types
 - Exposes search options such as `searchType`, `responseLength`,
-  `countryCode`, source filters, date filters, `fastMode`, `urlOnly`, and
-  `instructions`
+  `countryCode`, source filters, `sourceBiases`, date filters,
+  `historicalCache`, `fastMode`, `urlOnly`, and `instructions`
 - Exposes contents options such as `summary`, `extractEffort`,
-  `responseLength`, `maxPriceDollars`, and `screenshot`
-- Exposes answer and research options `responseLength` and `countryCode`
+  `responseLength`, `maxPriceDollars`, `screenshot`, date filters, and
+  `historicalCache`
+- Exposes answer options such as `structuredOutput`, `systemInstructions`,
+  `searchType`, `dataMaxPrice`, source filters, date filters, `countryCode`,
+  and `fastMode`
+- Exposes research options such as `mode`, `model`, `outputFormats`, `search`,
+  and `tools`
 - Persisted Valyu defaults are scoped under `providers.valyu.options.search`,
   `providers.valyu.options.contents`, `providers.valyu.options.answer`, and
   `providers.valyu.options.research`

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ Minimal config:
 - Exposes answer options such as `structuredOutput`, `systemInstructions`,
   `searchType`, `dataMaxPrice`, source filters, date filters, `countryCode`,
   and `fastMode`
-- Exposes research options such as `mode`, `model`, `outputFormats`, `search`,
+- Exposes research options such as `mode`, `outputFormats`, `search`,
   and `tools`
 - Persisted Valyu defaults are scoped under `providers.valyu.options.search`,
   `providers.valyu.options.contents`, `providers.valyu.options.answer`, and

--- a/bun.lock
+++ b/bun.lock
@@ -1,22 +1,21 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "pi-web-providers",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.3.177",
-        "@google/genai": "^2.8.0",
-        "@mendable/firecrawl-js": "^4.25.4",
-        "@openai/codex-sdk": "^0.139.0",
+        "@anthropic-ai/claude-agent-sdk": "^0.3.185",
+        "@google/genai": "^2.9.0",
+        "@mendable/firecrawl-js": "^4.28.2",
+        "@openai/codex-sdk": "^0.141.0",
         "@perplexity-ai/perplexity_ai": "^0.33.0",
         "@tavily/core": "^0.7.6",
         "cloudflare": "^6.4.0",
-        "exa-js": "^2.13.0",
+        "exa-js": "^2.14.0",
         "linkup-sdk": "^3.2.5",
-        "openai": "^6.42.0",
+        "openai": "^6.44.0",
         "parallel-web": "^1.1.0",
-        "valyu-js": "^2.8.0",
+        "valyu-js": "^2.9.0",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
@@ -37,23 +36,23 @@
     },
   },
   "packages": {
-    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.177", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.177", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.177", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.177", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.177", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.177", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.177", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.177", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.177" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-CBzXnzR661q3AlfZzBjmIFQx0cxr36iJV3PExTYmPyGQX32qxtiFQgnxTcF8wB4hcSVf2hnoy/gprVJdkNx7cw=="],
+    "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.3.185", "", { "optionalDependencies": { "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.185", "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.185", "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.185", "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.185", "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.185", "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.185", "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.185", "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.185" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.93.0", "@modelcontextprotocol/sdk": "^1.29.0", "zod": "^4.0.0" } }, "sha512-UDDd0cInvOufmR88btR/Ursnh71sb5scoutNlRS2L0LBdkt7JEqYJ0jt7DnOYHEVhMx8AAcg0eYgvXztcWUnFA=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.177", "", { "os": "darwin", "cpu": "arm64" }, "sha512-u9Ty+KPllm2nw0RatdPF0zcPRquNZjVptmyLG0DqduGbgZDLQpfPFMF5hffFIRnVaXhx7+jkUmEdw0jrda0UcA=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64": ["@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.185", "", { "os": "darwin", "cpu": "arm64" }, "sha512-P2Svxx1IFrS9aw4ylJBtcoJrc/OAOVnDs+o05x4TV7HoHUQUcKZ9XhWOGnadyVT0KLyoktgjyjnaK7Zdtc0Ldg=="],
 
-    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.177", "", { "os": "darwin", "cpu": "x64" }, "sha512-ona6Jv54XFwBTqOj3MzLWfKtc2m7Rdh58wOAX9Hnue/6FcWfyeuz/UDcidVTXQ7Xytz//Tb0JJgFtiQjO7FbIA=="],
+    "@anthropic-ai/claude-agent-sdk-darwin-x64": ["@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.185", "", { "os": "darwin", "cpu": "x64" }, "sha512-H69m2hIJawzSkCDNO/CPLQCYvDGdlbZdzGTgGF8/IQuB4O81sv8WSAh6TBXwtFXOgEi4HtrUYlxiFDmTHt7hMA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.177", "", { "os": "linux", "cpu": "arm64" }, "sha512-wBCbklkaDb483Ab4DUFfmJjZJKXz58YXPv+CiGsyjq1St19mbKEma5KKz3Ya9mlV8aLyh4zmLK2mEHPnF//Ipg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": ["@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.185", "", { "os": "linux", "cpu": "arm64" }, "sha512-KtXMCoprGYTSPb/A0/kjrO+PpDJAFbHhDd8rjqA4izU51OYjTDkahsGCcSTFM2jA8krOhPqzx/SNVuAVWmexwA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.177", "", { "os": "linux", "cpu": "arm64" }, "sha512-v6PMDD3h2erLuTK5S2ZvExqdL3v44OyC70XpKhyqIUnyPaGR9YAMjh//EKdWC+mNvt6mIbRZpaDcHtbASVW8Rw=="],
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": ["@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.185", "", { "os": "linux", "cpu": "arm64" }, "sha512-1GRpKYrg5foomW+qLrxm/k2R/5PEU7RAuEdX65HV6lFMJR3HsGj8qfBq4KCJHTS3r4YdVrFLvPQ/mUqbY6klIA=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.177", "", { "os": "linux", "cpu": "x64" }, "sha512-WDP6puwPHscggNAfvIxyUSHSAjfUEkGRfnMXEPBHOqO+qjX2KGxeE13/ih3EVioeBVOUIqPui6VB05vXLa6T9Q=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64": ["@anthropic-ai/claude-agent-sdk-linux-x64@0.3.185", "", { "os": "linux", "cpu": "x64" }, "sha512-8U5wu6dNcyzRkwoae0Gu5ZHs6lRSu8CXqd9yrilX3fHR9kKICrm76bLu5q2auuSc/8dx6VL5ZXqSzFKIMp//zw=="],
 
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.177", "", { "os": "linux", "cpu": "x64" }, "sha512-1cdEO06WoEsl1JnnLCPIlg/8x37GtBsTuj65gIpSjdrImNBjgIuMWVyceP4qaXhFjtQgYK1nx3TpaxEFVDOrDg=="],
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl": ["@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.185", "", { "os": "linux", "cpu": "x64" }, "sha512-YAky0Oez+YYrlcas/xDiaCm9AUX0z1YwM+pnk+CFxEr/ICmc7MbiFsnEIXFLPHaox9bE5iOzw4LS4b/c1tIJRg=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.177", "", { "os": "win32", "cpu": "arm64" }, "sha512-xLgDWnZaYohtFrkgEIkGZdP+rp4sXxAMbbpEvEp0LK1vAYmJam/ztT2yoK6gfI58IbToJq1WGUEX2HVnE65yOg=="],
+    "@anthropic-ai/claude-agent-sdk-win32-arm64": ["@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.185", "", { "os": "win32", "cpu": "arm64" }, "sha512-pJEOaCLQQQWSyBeseR/GAn4eEp4WtMDP/o5yPMuuAsNWeoJXM7cY4j/N3KBE6GZofgnYdWEXILF2uw3SjbtINA=="],
 
-    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.177", "", { "os": "win32", "cpu": "x64" }, "sha512-SIdQLbtF//rYK4KDBNpUPyjyui7NwCFPZ2/3vyW3TR8R8xynkNq3cLis90FnPSgxaSshi38vkJYWh+9kGDB7zg=="],
+    "@anthropic-ai/claude-agent-sdk-win32-x64": ["@anthropic-ai/claude-agent-sdk-win32-x64@0.3.185", "", { "os": "win32", "cpu": "x64" }, "sha512-/Kf9XneSuIkSHNwrxOVY0XT7RovAEcx5nDASKzku4994cZz54otU5mT2jT6dwevDLEStfgts5x/A4z0AePwVTQ=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
 
@@ -187,7 +186,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
 
-    "@google/genai": ["@google/genai@2.8.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-pc2ayxqO5+O7AvnHBqpNHIk7PAZkHZgL31tbyx0gJZBSS9qPYiQoqwK7oYOw/ePmG6QY4EMSu+304vD5QlhXAw=="],
+    "@google/genai": ["@google/genai@2.9.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-3DRdSJ0LaKFig3FNGeRDn9BQxtjZm2qr0hNH2d771LKcG0HvUYddlN0LPdSp8XU7Ekb04i9q3+tt64uYqavUdw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.12", "", { "peerDependencies": { "hono": "^4" } }, "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw=="],
 
@@ -217,7 +216,7 @@
 
     "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
 
-    "@mendable/firecrawl-js": ["@mendable/firecrawl-js@4.25.4", "", { "dependencies": { "axios": "1.16.1", "firecrawl": "4.16.0", "typescript-event-target": "^1.1.1", "zod": "^3.23.8", "zod-to-json-schema": "^3.23.0" } }, "sha512-kjtEdRAaIYD/rOU8Gk/uKgSjexMJYvXipGqAFy23VJ7UQpwtavcGGIB+iGecNvhMT2BJL1yBq2dED/mu5sj9sg=="],
+    "@mendable/firecrawl-js": ["@mendable/firecrawl-js@4.28.2", "", { "dependencies": { "axios": "1.18.0", "firecrawl": "4.16.0", "typescript-event-target": "^1.1.1", "zod": "^3.23.8", "zod-to-json-schema": "^3.23.0" } }, "sha512-OijCdgSdS+wWzaUvGoA1Orthc/is8k1GNmYNQo5b2GdfW2mTLVZpYGQQzujXUxnbT/PFx5DCuvWGtmolX/PbAA=="],
 
     "@mistralai/mistralai": ["@mistralai/mistralai@2.2.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ=="],
 
@@ -225,21 +224,21 @@
 
     "@nodable/entities": ["@nodable/entities@2.2.0", "", {}, "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg=="],
 
-    "@openai/codex": ["@openai/codex@0.139.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.139.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.139.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.139.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.139.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.139.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.139.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-wr2fRE+fzW0CjEbfFsLh1ftarVEcw0CMLWS7QyA0nyOz5qacQPVq3cq2+/U7oEbwm1TOqoi0Fm1nxniB5FkpmA=="],
+    "@openai/codex": ["@openai/codex@0.141.0", "", { "optionalDependencies": { "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64", "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64", "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64", "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64", "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64", "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64" }, "bin": { "codex": "bin/codex.js" } }, "sha512-ACpAn/Z7JwBg431040zKOLpBtNdP024ixqwC/R2YM5tPrLG0wfSmrd/AVHPUExt6hOO6fEHwxM/ixAyzFleQXw=="],
 
-    "@openai/codex-darwin-arm64": ["@openai/codex@0.139.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-o+0ZKWwgDFMMLO7rwinzO0PQsgK+Vme1pMN2GeAxsX29ZgGZcyPICfpJbeGSUO1mb2a36Skjx6nfdRnxMY0r7w=="],
+    "@openai/codex-darwin-arm64": ["@openai/codex@0.141.0-darwin-arm64", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BuroZvQQLJYLfQEG7MKMdxHtggDDlxeJCTot//MwEnbW8ga7P319EPos/FyOK9r/gh+E/KGxk+YAzEoHZPRGEg=="],
 
-    "@openai/codex-darwin-x64": ["@openai/codex@0.139.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-9gkBWzu6DB2rqU4DbpxD3DE5bofGpsK46Lp0h0I+bKWc2IIcxvSi8K2utKmBLoJCbKrn4JQu7dFNGRqEfENung=="],
+    "@openai/codex-darwin-x64": ["@openai/codex@0.141.0-darwin-x64", "", { "os": "darwin", "cpu": "x64" }, "sha512-kDP+egfjp3cuao1r9AdD8/skBxM7saT007VE82DB9mRUcqgKaxYHoPaHmKhlYOlFwPam0zsD6ORT6GJJhvGAKg=="],
 
-    "@openai/codex-linux-arm64": ["@openai/codex@0.139.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-tBQE5lZciRHeWZGuURgjP9S717MvTIpQMc593+DNxY2LQxozkngOkzFSQd1+/UmQKGrCqdFLu5irIwPXpSZyEw=="],
+    "@openai/codex-linux-arm64": ["@openai/codex@0.141.0-linux-arm64", "", { "os": "linux", "cpu": "arm64" }, "sha512-jXAOSjMqAUUgfMo9ciAkioJKKAYDwOE40bLx4/2jR7Tfu4u9409X5fQlLuNLMgnlfuzUEk/UiibQE62a70bQaw=="],
 
-    "@openai/codex-linux-x64": ["@openai/codex@0.139.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-14UgzDS+X4crkvdt6S02A/ZZOrS8ZyWiuTRpguCtnhNamb7unSuDxy86BWgpAl3sqiTaN2CP8VLyp2ohQ8Nbzw=="],
+    "@openai/codex-linux-x64": ["@openai/codex@0.141.0-linux-x64", "", { "os": "linux", "cpu": "x64" }, "sha512-q3xv538DT/Sb8rRq8apdKgrgA/isqs1fDfE5JhRDMmojYFA3zwDldlmdWWGdS3APtjf5UrDsqljSE9JHxnlWNA=="],
 
-    "@openai/codex-sdk": ["@openai/codex-sdk@0.139.0", "", { "dependencies": { "@openai/codex": "0.139.0" } }, "sha512-r4lDckaVx4mVZy1v/7ykEhkeWjVfM/4oGJfhG0AP4+zN3Sa+jcf5hdY4EHfJasofBcp0tIF/7JCKHpv534R+tw=="],
+    "@openai/codex-sdk": ["@openai/codex-sdk@0.141.0", "", { "dependencies": { "@openai/codex": "0.141.0" } }, "sha512-VCLsSJGSoOHcVAC/2+NrhtiBiCP/XF8YmCzzGocm8qNkAPN3a/+CcrvwUmvNSH53dU3TVi5Hp5zddov16BXLHw=="],
 
-    "@openai/codex-win32-arm64": ["@openai/codex@0.139.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-nlwRjsYotH1Rtqu/Q0VwQbIeO2UX1mkHK84Ov9qn/hl29QqqoBtno0tRyqIPbkXFIVQuWiAYXlV3ugLwH5fTrQ=="],
+    "@openai/codex-win32-arm64": ["@openai/codex@0.141.0-win32-arm64", "", { "os": "win32", "cpu": "arm64" }, "sha512-87X5tvH1RmKQOHbgO5Cv+S0aXJ+saHTSSHEasJjbB1FtUoLbao29NTnkpkB2dAV3xtUJ/dmE8NgvbFEeWuMqUQ=="],
 
-    "@openai/codex-win32-x64": ["@openai/codex@0.139.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-lQrVLNz+90wdvWVNFDvCkHQRiAK9ZllmkTka3c8eqSDqdJk35Gpgppfv9Xtw5M2ZBtTq0sBdWBiCMyzGDBSpmQ=="],
+    "@openai/codex-win32-x64": ["@openai/codex@0.141.0-win32-x64", "", { "os": "win32", "cpu": "x64" }, "sha512-4gur4DgFQIOc+DopNOI90IpNA66qBIyc5Lb5QYy66OOCXOvXpbOCpScuEFmT1xpaTzNUYhlRGA2NFWqSHQrKUQ=="],
 
     "@perplexity-ai/perplexity_ai": ["@perplexity-ai/perplexity_ai@0.33.0", "", {}, "sha512-r4HHrImwF+bC3yNb9u9dTgxhTEBs6QzHQqLmWHUmPNd2IIc8lbiKkw2tUsHkxCe49Ymn+nkORxxsFON3T3OK3Q=="],
 
@@ -387,7 +386,7 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
-    "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
+    "axios": ["axios@1.18.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -485,7 +484,7 @@
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
-    "exa-js": ["exa-js@2.13.0", "", { "dependencies": { "cross-fetch": "~4.1.0", "dotenv": "~16.4.7", "openai": "^5.0.1", "zod": "^3.22.0", "zod-to-json-schema": "^3.20.0" } }, "sha512-G6BCMCMWdqVKKaKkNxHB5R/7xoT8JXVkdZ1nfaBejlMH90T95rlmEYdu2WJI2ZKEIm755vFLlNSobgVNPJCbYg=="],
+    "exa-js": ["exa-js@2.14.0", "", { "dependencies": { "cross-fetch": "~4.1.0", "dotenv": "~16.4.7", "openai": "^5.0.1", "zod": "^3.22.0", "zod-to-json-schema": "^3.20.0" } }, "sha512-oTeVPJZ3cUkZNcIQvslyVpmGqp98caQwkmApJAYoGKr4GC2Uc8kETdeCffnegaKiFZNOMr6pQLH9/t6Z3tYc/A=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
@@ -651,7 +650,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "openai": ["openai@6.42.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"] }, "sha512-1WFEt/uXMXOLhYRNkgJWo08Y2YNvNwpVU72K7ibrWgWpNOXd4VojXLbe6SQ4bLiUQ3Y8jz4IiyVkylJCL1DtZg=="],
+    "openai": ["openai@6.44.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"] }, "sha512-09/gH+8jH0RgUwsgWHAaxsKGRT5zVZ95IaJUnqAWj6XejIBmnFRwq2WUIF37VtDEsmGrtPmvCs5+yBSeZGWvkA=="],
 
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 
@@ -779,7 +778,7 @@
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
-    "valyu-js": ["valyu-js@2.8.0", "", { "dependencies": { "axios": "^1.15.0" } }, "sha512-3DTVvVuUScs213a7E1YMflRLAaKfAeFozq7h+0hTi8Lo8pfYjSDU6vDWdJRDY1pHVMmgFsHNAwDoA7Orus/UEg=="],
+    "valyu-js": ["valyu-js@2.9.0", "", { "dependencies": { "axios": "^1.15.0" } }, "sha512-xWi6ccK4uSp2YZQxWYbIesl+3YvffQ3waVyUDagsGM9LVVJSm8Xt9LTEiWbyNrvjJScZswqQcKSOHqKhoNfi9Q=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -869,6 +868,8 @@
 
     "@mendable/firecrawl-js/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@tavily/core/axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
+
     "@types/node-fetch/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
@@ -907,7 +908,7 @@
 
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "valyu-js/axios": ["axios@1.15.2", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A=="],
+    "valyu-js/axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
 
     "vite/esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": "bin/esbuild" }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -924,6 +925,8 @@
     "@aws-crypto/sha256-js/@aws-sdk/types/@smithy/types": ["@smithy/types@4.13.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw=="],
 
     "@aws-crypto/util/@aws-sdk/types/@smithy/types": ["@smithy/types@4.13.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw=="],
+
+    "@tavily/core/axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "@types/node-fetch/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -945,7 +948,7 @@
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "valyu-js/axios/follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
+    "valyu-js/axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
@@ -1003,9 +1006,13 @@
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "@tavily/core/axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "valyu-js/axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
     "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }

--- a/changelog/unreleased/bun-install-sdk-version-drift.md
+++ b/changelog/unreleased/bun-install-sdk-version-drift.md
@@ -1,0 +1,26 @@
+---
+title: Provider SDK dependency updates
+type: bugfix
+authors:
+  - mavam
+  - codex
+prs:
+  - 34
+created: 2026-06-21T11:17:44.05824Z
+---
+
+Bun-based installs now use refreshed provider SDK dependencies for Claude, Gemini, Firecrawl, Codex, Exa, OpenAI, and Valyu.
+
+| SDK | Previous | Current |
+| --- | --- | --- |
+| `@anthropic-ai/claude-agent-sdk` | `0.3.177` | `0.3.185` |
+| `@google/genai` | `2.8.0` | `2.9.0` |
+| `@mendable/firecrawl-js` | `4.25.4` | `4.28.2` |
+| `@openai/codex-sdk` | `0.139.0` | `0.141.0` |
+| `exa-js` | `2.13.0` | `2.14.0` |
+| `openai` | `6.42.0` | `6.44.0` |
+| `valyu-js` | `2.8.0` | `2.9.0` |
+
+The exposed provider options now include current OpenAI web search controls (`searchContextSize`, `allowedDomains`, and `userLocation`), Exa freshness and content controls, Firecrawl domain filters and scrape options, and Valyu source, answer, and research controls.
+
+No longer supported options are no longer advertised, including Exa `deep-max` search mode and Valyu answer/research `responseLength`.

--- a/src/provider-config-manifests.ts
+++ b/src/provider-config-manifests.ts
@@ -414,9 +414,9 @@ const PROVIDER_SETTINGS = {
           "hybrid",
           "fast",
           "instant",
+          "deep-lite",
           "deep",
           "deep-reasoning",
-          "deep-max",
         ],
         getValue: (config) =>
           readString(getExaSearchOptions(config)?.type) ?? "default",
@@ -754,29 +754,21 @@ const PROVIDER_SETTINGS = {
         },
       }),
       valuesSetting<Valyu>({
-        id: "valyuAnswerResponseLength",
-        label: "Answer response length",
-        help: "Valyu answer response length. 'default' uses the SDK default.",
-        values: ["default", "short", "medium", "large", "max"],
+        id: "valyuResearchMode",
+        label: "Research mode",
+        help: "Valyu research mode. 'default' uses the SDK default.",
+        values: ["default", "fast", "standard", "lite", "heavy", "max"],
         getValue: (config) =>
-          readString(
-            getValyuCapabilityOptions(config, "answer")?.responseLength,
-          ) ?? "default",
+          readString(getValyuCapabilityOptions(config, "research")?.mode) ??
+          "default",
         setValue: (config, value) => {
-          setValyuResponseLength(config, "answer", value);
-        },
-      }),
-      valuesSetting<Valyu>({
-        id: "valyuResearchResponseLength",
-        label: "Research response length",
-        help: "Valyu research response length. 'default' uses the SDK default.",
-        values: ["default", "short", "medium", "large", "max"],
-        getValue: (config) =>
-          readString(
-            getValyuCapabilityOptions(config, "research")?.responseLength,
-          ) ?? "default",
-        setValue: (config, value) => {
-          setValyuResponseLength(config, "research", value);
+          const options = ensureValyuCapabilityOptions(config, "research");
+          if (value === "default") {
+            delete options.mode;
+          } else {
+            options.mode = value;
+          }
+          cleanupCapabilityOptions(config, ["search", "answer", "research"]);
         },
       }),
     ],

--- a/src/providers/exa.ts
+++ b/src/providers/exa.ts
@@ -34,9 +34,9 @@ const exaSearchOptionsSchema = Type.Object(
           "hybrid",
           "fast",
           "instant",
+          "deep-lite",
           "deep",
           "deep-reasoning",
-          "deep-max",
         ],
         { description: "Exa search mode." },
       ),
@@ -54,6 +54,14 @@ const exaSearchOptionsSchema = Type.Object(
     excludeDomains: Type.Optional(
       Type.Array(Type.String(), { description: "Exclude these domains." }),
     ),
+    startCrawlDate: Type.Optional(
+      Type.String({
+        description: "ISO date string for earliest crawl date.",
+      }),
+    ),
+    endCrawlDate: Type.Optional(
+      Type.String({ description: "ISO date string for latest crawl date." }),
+    ),
     startPublishedDate: Type.Optional(
       Type.String({
         description: "ISO date string for earliest publish date.",
@@ -62,43 +70,166 @@ const exaSearchOptionsSchema = Type.Object(
     endPublishedDate: Type.Optional(
       Type.String({ description: "ISO date string for latest publish date." }),
     ),
+    includeText: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Require result page text to contain these terms. Exa currently supports one short phrase.",
+      }),
+    ),
+    excludeText: Type.Optional(
+      Type.Array(Type.String(), {
+        description:
+          "Require result page text not to contain these terms. Exa currently supports one short phrase.",
+      }),
+    ),
+    systemPrompt: Type.Optional(
+      Type.String({
+        description:
+          "Additional Exa instructions for deep search source selection and synthesis.",
+      }),
+    ),
+    additionalQueries: Type.Optional(
+      Type.Array(Type.String(), {
+        maxItems: 5,
+        description:
+          "Alternative query formulations for Exa deep search variants.",
+      }),
+    ),
     userLocation: Type.Optional(
-      Type.Object(
-        {
-          country: Type.Optional(
-            Type.String({ description: "Country hint for the user location." }),
-          ),
-          region: Type.Optional(
-            Type.String({ description: "Region hint for the user location." }),
-          ),
-          city: Type.Optional(
-            Type.String({ description: "City hint for the user location." }),
-          ),
-          timezone: Type.Optional(
-            Type.String({
-              description: "Timezone hint for the user location.",
-            }),
-          ),
-        },
-        {
-          description: "User location hint passed through to the Exa SDK.",
-        },
-      ),
+      Type.String({
+        description:
+          "Two-letter ISO country code for the user location, such as 'US'.",
+      }),
     ),
     contents: Type.Optional(
       Type.Object(
         {
           text: Type.Optional(
-            Type.Boolean({ description: "Include text content." }),
+            Type.Union(
+              [
+                Type.Boolean(),
+                Type.Object(
+                  {
+                    maxCharacters: Type.Optional(
+                      Type.Integer({
+                        minimum: 1,
+                        description: "Maximum text characters per result.",
+                      }),
+                    ),
+                    includeHtmlTags: Type.Optional(
+                      Type.Boolean({
+                        description: "Include HTML tags in returned text.",
+                      }),
+                    ),
+                    verbosity: Type.Optional(
+                      literalUnion(["compact", "standard", "full"], {
+                        description: "Verbosity level for returned text.",
+                      }),
+                    ),
+                  },
+                  { additionalProperties: false },
+                ),
+              ],
+              { description: "Include text content." },
+            ),
           ),
           highlights: Type.Optional(
-            Type.Boolean({ description: "Include highlighted excerpts." }),
+            Type.Union(
+              [
+                Type.Boolean(),
+                Type.Object(
+                  {
+                    query: Type.Optional(
+                      Type.String({
+                        description: "Query to use for highlights.",
+                      }),
+                    ),
+                    maxCharacters: Type.Optional(
+                      Type.Integer({
+                        minimum: 1,
+                        description: "Maximum highlight characters.",
+                      }),
+                    ),
+                  },
+                  { additionalProperties: false },
+                ),
+              ],
+              { description: "Include highlighted excerpts." },
+            ),
           ),
           summary: Type.Optional(
-            Type.Boolean({ description: "Include AI-generated summary." }),
+            Type.Union(
+              [
+                Type.Boolean(),
+                Type.Object(
+                  {
+                    query: Type.Optional(
+                      Type.String({
+                        description: "Query to guide summary generation.",
+                      }),
+                    ),
+                  },
+                  { additionalProperties: false },
+                ),
+              ],
+              { description: "Include AI-generated summary." },
+            ),
+          ),
+          livecrawl: Type.Optional(
+            literalUnion(["never", "fallback", "always", "auto", "preferred"], {
+              description: "Livecrawl mode for fetching fresh content.",
+            }),
+          ),
+          livecrawlTimeout: Type.Optional(
+            Type.Integer({
+              minimum: 0,
+              description: "Livecrawl timeout in milliseconds.",
+            }),
+          ),
+          maxAgeHours: Type.Optional(
+            Type.Number({
+              description:
+                "Maximum age of cached content in hours. Use 0 to always fetch fresh content.",
+            }),
+          ),
+          filterEmptyResults: Type.Optional(
+            Type.Boolean({ description: "Filter results with no contents." }),
+          ),
+          subpages: Type.Optional(
+            Type.Integer({
+              minimum: 0,
+              description: "Number of subpages to return for each result.",
+            }),
+          ),
+          subpageTarget: Type.Optional(
+            Type.Union([Type.String(), Type.Array(Type.String())], {
+              description: "Text used to match/rank returned subpages.",
+            }),
+          ),
+          extras: Type.Optional(
+            Type.Object(
+              {
+                links: Type.Optional(
+                  Type.Integer({
+                    minimum: 0,
+                    description: "Number of page links to include.",
+                  }),
+                ),
+                imageLinks: Type.Optional(
+                  Type.Integer({
+                    minimum: 0,
+                    description: "Number of image links to include.",
+                  }),
+                ),
+              },
+              { additionalProperties: false },
+            ),
           ),
         },
-        { description: "What content to include in results." },
+        {
+          additionalProperties: false,
+          description: "What content to include in results.",
+        },
       ),
     ),
   },
@@ -109,6 +240,8 @@ const exaSearchPromptGuidelines = [
   "Use Exa's neural/auto search modes for semantic source discovery where exact keywords are uncertain; use keyword mode when exact terms, names, or identifiers matter.",
   "Use Exa category filters such as 'research paper' or 'company' when the user asks for a specific source type.",
   "Set includeDomains or excludeDomains when the task names preferred sources, requires primary sources, or needs noisy domains filtered out.",
+  "Use startCrawlDate/endCrawlDate or contents.maxAgeHours when freshness of Exa's crawled content matters.",
+  "Use includeText/excludeText for short required or forbidden phrases in page text.",
   "Request contents.text, contents.highlights, or contents.summary only when snippets are insufficient and richer source context is needed directly in search results.",
 ] as const;
 

--- a/src/providers/firecrawl.ts
+++ b/src/providers/firecrawl.ts
@@ -12,8 +12,8 @@ import type {
   ProviderContext,
   SearchResponse,
   SearchResult,
-  ToolOutput,
   Tool,
+  ToolOutput,
 } from "../types.js";
 import { defineCapability, defineProvider } from "./definition.js";
 import { literalUnion } from "./schema.js";
@@ -128,6 +128,100 @@ const firecrawlSearchPromptGuidelines = [
   "Prefer web_contents with Firecrawl scrape options after search when only a small set of known URLs needs full extraction.",
 ] as const;
 
+// Scrape tuning controls shared by `web_contents` (scrape) and `web_answer`.
+const firecrawlScrapeTuningProperties = {
+  onlyMainContent: Type.Optional(
+    Type.Boolean({ description: "Extract only the main content." }),
+  ),
+  includeTags: Type.Optional(
+    Type.Array(Type.String(), { description: "CSS selectors to include." }),
+  ),
+  excludeTags: Type.Optional(
+    Type.Array(Type.String(), { description: "CSS selectors to exclude." }),
+  ),
+  waitFor: Type.Optional(
+    Type.Integer({
+      minimum: 0,
+      description: "Milliseconds to wait before scraping.",
+    }),
+  ),
+  headers: Type.Optional(
+    Type.Record(Type.String(), Type.String(), {
+      description: "Headers to send when scraping.",
+    }),
+  ),
+  location: Type.Optional(
+    Type.Object(
+      {
+        country: Type.Optional(Type.String({ description: "Country hint." })),
+        region: Type.Optional(Type.String({ description: "Region hint." })),
+        city: Type.Optional(Type.String({ description: "City hint." })),
+      },
+      { description: "Location hint for scraping." },
+    ),
+  ),
+  mobile: Type.Optional(
+    Type.Boolean({ description: "Use a mobile browser profile." }),
+  ),
+  proxy: Type.Optional(
+    Type.String({
+      description: "Proxy mode passed through to the Firecrawl SDK.",
+    }),
+  ),
+  fastMode: Type.Optional(
+    Type.Boolean({ description: "Use Firecrawl fast mode." }),
+  ),
+  blockAds: Type.Optional(
+    Type.Boolean({ description: "Block ads while scraping." }),
+  ),
+  removeBase64Images: Type.Optional(
+    Type.Boolean({
+      description: "Remove base64 image data from scraped output.",
+    }),
+  ),
+  redactPII: Type.Optional(
+    Type.Union(
+      [
+        Type.Boolean(),
+        Type.Object(
+          {
+            entities: Type.Optional(
+              Type.Array(
+                literalUnion([
+                  "PERSON",
+                  "EMAIL",
+                  "PHONE",
+                  "LOCATION",
+                  "FINANCIAL",
+                  "SECRET",
+                ]),
+              ),
+            ),
+          },
+          { additionalProperties: false },
+        ),
+      ],
+      { description: "Redact personal or sensitive data from output." },
+    ),
+  ),
+  maxAge: Type.Optional(
+    Type.Number({
+      description: "Maximum age of cached scrape data in milliseconds.",
+    }),
+  ),
+  minAge: Type.Optional(
+    Type.Number({
+      description: "Minimum age of cached scrape data in milliseconds.",
+    }),
+  ),
+  storeInCache: Type.Optional(
+    Type.Boolean({ description: "Store scrape result in Firecrawl cache." }),
+  ),
+  skipTlsVerification: Type.Optional(
+    Type.Boolean({ description: "Skip TLS certificate verification." }),
+  ),
+} as const;
+
 const firecrawlScrapeOptionsSchema = Type.Object(
   {
     formats: Type.Optional(
@@ -149,102 +243,13 @@ const firecrawlScrapeOptionsSchema = Type.Object(
         },
       ),
     ),
-    onlyMainContent: Type.Optional(
-      Type.Boolean({ description: "Extract only the main content." }),
-    ),
-    includeTags: Type.Optional(
-      Type.Array(Type.String(), { description: "CSS selectors to include." }),
-    ),
-    excludeTags: Type.Optional(
-      Type.Array(Type.String(), { description: "CSS selectors to exclude." }),
-    ),
-    waitFor: Type.Optional(
-      Type.Integer({
-        minimum: 0,
-        description: "Milliseconds to wait before scraping.",
-      }),
-    ),
     timeout: Type.Optional(
       Type.Integer({
         minimum: 0,
         description: "Request timeout in milliseconds.",
       }),
     ),
-    headers: Type.Optional(
-      Type.Record(Type.String(), Type.String(), {
-        description: "Headers to send when scraping.",
-      }),
-    ),
-    location: Type.Optional(
-      Type.Object(
-        {
-          country: Type.Optional(Type.String({ description: "Country hint." })),
-          region: Type.Optional(Type.String({ description: "Region hint." })),
-          city: Type.Optional(Type.String({ description: "City hint." })),
-        },
-        { description: "Location hint for scraping." },
-      ),
-    ),
-    mobile: Type.Optional(
-      Type.Boolean({ description: "Use a mobile browser profile." }),
-    ),
-    proxy: Type.Optional(
-      Type.String({
-        description: "Proxy mode passed through to the Firecrawl SDK.",
-      }),
-    ),
-    fastMode: Type.Optional(
-      Type.Boolean({ description: "Use Firecrawl fast mode." }),
-    ),
-    blockAds: Type.Optional(
-      Type.Boolean({ description: "Block ads while scraping." }),
-    ),
-    removeBase64Images: Type.Optional(
-      Type.Boolean({
-        description: "Remove base64 image data from scraped output.",
-      }),
-    ),
-    redactPII: Type.Optional(
-      Type.Union(
-        [
-          Type.Boolean(),
-          Type.Object(
-            {
-              entities: Type.Optional(
-                Type.Array(
-                  literalUnion([
-                    "PERSON",
-                    "EMAIL",
-                    "PHONE",
-                    "LOCATION",
-                    "FINANCIAL",
-                    "SECRET",
-                  ]),
-                ),
-              ),
-            },
-            { additionalProperties: false },
-          ),
-        ],
-        { description: "Redact personal or sensitive data from output." },
-      ),
-    ),
-    maxAge: Type.Optional(
-      Type.Number({
-        description: "Maximum age of cached scrape data in milliseconds.",
-      }),
-    ),
-    minAge: Type.Optional(
-      Type.Number({
-        description: "Minimum age of cached scrape data in milliseconds.",
-      }),
-    ),
-    storeInCache: Type.Optional(
-      Type.Boolean({ description: "Store scrape result in Firecrawl cache." }),
-    ),
-    skipTlsVerification: Type.Optional(
-      Type.Boolean({ description: "Skip TLS certificate verification." }),
-    ),
+    ...firecrawlScrapeTuningProperties,
   },
   { description: "Firecrawl scrape options." },
 );
@@ -255,96 +260,7 @@ const firecrawlAnswerOptionsSchema = Type.Object(
       minLength: 1,
       description: "URL of the page to ask about.",
     }),
-    onlyMainContent: Type.Optional(
-      Type.Boolean({ description: "Extract only the main content." }),
-    ),
-    includeTags: Type.Optional(
-      Type.Array(Type.String(), { description: "CSS selectors to include." }),
-    ),
-    excludeTags: Type.Optional(
-      Type.Array(Type.String(), { description: "CSS selectors to exclude." }),
-    ),
-    waitFor: Type.Optional(
-      Type.Integer({
-        minimum: 0,
-        description: "Milliseconds to wait before scraping.",
-      }),
-    ),
-    headers: Type.Optional(
-      Type.Record(Type.String(), Type.String(), {
-        description: "Headers to send when scraping.",
-      }),
-    ),
-    location: Type.Optional(
-      Type.Object(
-        {
-          country: Type.Optional(Type.String({ description: "Country hint." })),
-          region: Type.Optional(Type.String({ description: "Region hint." })),
-          city: Type.Optional(Type.String({ description: "City hint." })),
-        },
-        { description: "Location hint for scraping." },
-      ),
-    ),
-    mobile: Type.Optional(
-      Type.Boolean({ description: "Use a mobile browser profile." }),
-    ),
-    proxy: Type.Optional(
-      Type.String({
-        description: "Proxy mode passed through to Firecrawl.",
-      }),
-    ),
-    fastMode: Type.Optional(
-      Type.Boolean({ description: "Use Firecrawl fast mode." }),
-    ),
-    blockAds: Type.Optional(
-      Type.Boolean({ description: "Block ads while scraping." }),
-    ),
-    removeBase64Images: Type.Optional(
-      Type.Boolean({
-        description: "Remove base64 image data from scraped output.",
-      }),
-    ),
-    redactPII: Type.Optional(
-      Type.Union(
-        [
-          Type.Boolean(),
-          Type.Object(
-            {
-              entities: Type.Optional(
-                Type.Array(
-                  literalUnion([
-                    "PERSON",
-                    "EMAIL",
-                    "PHONE",
-                    "LOCATION",
-                    "FINANCIAL",
-                    "SECRET",
-                  ]),
-                ),
-              ),
-            },
-            { additionalProperties: false },
-          ),
-        ],
-        { description: "Redact personal or sensitive data from output." },
-      ),
-    ),
-    maxAge: Type.Optional(
-      Type.Number({
-        description: "Maximum age of cached scrape data in milliseconds.",
-      }),
-    ),
-    minAge: Type.Optional(
-      Type.Number({
-        description: "Minimum age of cached scrape data in milliseconds.",
-      }),
-    ),
-    storeInCache: Type.Optional(
-      Type.Boolean({ description: "Store scrape result in Firecrawl cache." }),
-    ),
-    skipTlsVerification: Type.Optional(
-      Type.Boolean({ description: "Skip TLS certificate verification." }),
-    ),
+    ...firecrawlScrapeTuningProperties,
   },
   {
     description:

--- a/src/providers/firecrawl.ts
+++ b/src/providers/firecrawl.ts
@@ -50,6 +50,26 @@ const firecrawlSearchOptionsSchema = Type.Object(
         description: "Search categories to include.",
       }),
     ),
+    includeDomains: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Restrict results to these domains.",
+      }),
+    ),
+    excludeDomains: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Exclude these domains.",
+      }),
+    ),
+    tbs: Type.Optional(
+      Type.String({
+        description: "Google-style time-based search filter.",
+      }),
+    ),
+    ignoreInvalidURLs: Type.Optional(
+      Type.Boolean({
+        description: "Ignore invalid result URLs returned by search.",
+      }),
+    ),
     location: Type.Optional(
       Type.Object(
         {
@@ -70,9 +90,22 @@ const firecrawlSearchOptionsSchema = Type.Object(
       Type.Object(
         {
           formats: Type.Optional(
-            Type.Array(literalUnion(["markdown", "html", "rawHtml"]), {
-              description: "Output formats.",
-            }),
+            Type.Array(
+              literalUnion([
+                "markdown",
+                "html",
+                "rawHtml",
+                "links",
+                "images",
+                "screenshot",
+                "summary",
+                "json",
+                "attributes",
+              ]),
+              {
+                description: "Output formats.",
+              },
+            ),
           ),
           onlyMainContent: Type.Optional(
             Type.Boolean({ description: "Extract only the main content." }),
@@ -90,6 +123,7 @@ const firecrawlSearchOptionsSchema = Type.Object(
 const firecrawlSearchPromptGuidelines = [
   "Use Firecrawl search when the task benefits from searchable results that can also include scraped page content through scrapeOptions.",
   "Set scrapeOptions.formats=['markdown'] and onlyMainContent=true when source snippets are not enough and the user needs extracted page context in the search results.",
+  "Use includeDomains/excludeDomains when search should stay within or avoid specific sites.",
   "Use lang, country, or location when the user asks for language-specific, country-specific, or local results.",
   "Prefer web_contents with Firecrawl scrape options after search when only a small set of known URLs needs full extraction.",
 ] as const;
@@ -97,9 +131,23 @@ const firecrawlSearchPromptGuidelines = [
 const firecrawlScrapeOptionsSchema = Type.Object(
   {
     formats: Type.Optional(
-      Type.Array(literalUnion(["markdown", "html", "rawHtml"]), {
-        description: "Output formats for scraping.",
-      }),
+      Type.Array(
+        literalUnion([
+          "markdown",
+          "html",
+          "rawHtml",
+          "links",
+          "images",
+          "screenshot",
+          "summary",
+          "json",
+          "attributes",
+          "changeTracking",
+        ]),
+        {
+          description: "Output formats for scraping.",
+        },
+      ),
     ),
     onlyMainContent: Type.Optional(
       Type.Boolean({ description: "Extract only the main content." }),
@@ -114,6 +162,12 @@ const firecrawlScrapeOptionsSchema = Type.Object(
       Type.Integer({
         minimum: 0,
         description: "Milliseconds to wait before scraping.",
+      }),
+    ),
+    timeout: Type.Optional(
+      Type.Integer({
+        minimum: 0,
+        description: "Request timeout in milliseconds.",
       }),
     ),
     headers: Type.Optional(
@@ -138,6 +192,58 @@ const firecrawlScrapeOptionsSchema = Type.Object(
       Type.String({
         description: "Proxy mode passed through to the Firecrawl SDK.",
       }),
+    ),
+    fastMode: Type.Optional(
+      Type.Boolean({ description: "Use Firecrawl fast mode." }),
+    ),
+    blockAds: Type.Optional(
+      Type.Boolean({ description: "Block ads while scraping." }),
+    ),
+    removeBase64Images: Type.Optional(
+      Type.Boolean({
+        description: "Remove base64 image data from scraped output.",
+      }),
+    ),
+    redactPII: Type.Optional(
+      Type.Union(
+        [
+          Type.Boolean(),
+          Type.Object(
+            {
+              entities: Type.Optional(
+                Type.Array(
+                  literalUnion([
+                    "PERSON",
+                    "EMAIL",
+                    "PHONE",
+                    "LOCATION",
+                    "FINANCIAL",
+                    "SECRET",
+                  ]),
+                ),
+              ),
+            },
+            { additionalProperties: false },
+          ),
+        ],
+        { description: "Redact personal or sensitive data from output." },
+      ),
+    ),
+    maxAge: Type.Optional(
+      Type.Number({
+        description: "Maximum age of cached scrape data in milliseconds.",
+      }),
+    ),
+    minAge: Type.Optional(
+      Type.Number({
+        description: "Minimum age of cached scrape data in milliseconds.",
+      }),
+    ),
+    storeInCache: Type.Optional(
+      Type.Boolean({ description: "Store scrape result in Firecrawl cache." }),
+    ),
+    skipTlsVerification: Type.Optional(
+      Type.Boolean({ description: "Skip TLS certificate verification." }),
     ),
   },
   { description: "Firecrawl scrape options." },
@@ -186,6 +292,58 @@ const firecrawlAnswerOptionsSchema = Type.Object(
       Type.String({
         description: "Proxy mode passed through to Firecrawl.",
       }),
+    ),
+    fastMode: Type.Optional(
+      Type.Boolean({ description: "Use Firecrawl fast mode." }),
+    ),
+    blockAds: Type.Optional(
+      Type.Boolean({ description: "Block ads while scraping." }),
+    ),
+    removeBase64Images: Type.Optional(
+      Type.Boolean({
+        description: "Remove base64 image data from scraped output.",
+      }),
+    ),
+    redactPII: Type.Optional(
+      Type.Union(
+        [
+          Type.Boolean(),
+          Type.Object(
+            {
+              entities: Type.Optional(
+                Type.Array(
+                  literalUnion([
+                    "PERSON",
+                    "EMAIL",
+                    "PHONE",
+                    "LOCATION",
+                    "FINANCIAL",
+                    "SECRET",
+                  ]),
+                ),
+              ),
+            },
+            { additionalProperties: false },
+          ),
+        ],
+        { description: "Redact personal or sensitive data from output." },
+      ),
+    ),
+    maxAge: Type.Optional(
+      Type.Number({
+        description: "Maximum age of cached scrape data in milliseconds.",
+      }),
+    ),
+    minAge: Type.Optional(
+      Type.Number({
+        description: "Minimum age of cached scrape data in milliseconds.",
+      }),
+    ),
+    storeInCache: Type.Optional(
+      Type.Boolean({ description: "Store scrape result in Firecrawl cache." }),
+    ),
+    skipTlsVerification: Type.Optional(
+      Type.Boolean({ description: "Skip TLS certificate verification." }),
     ),
   },
   {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -17,6 +17,7 @@ import type {
   ToolOutput,
 } from "../types.js";
 import { defineCapability, defineProvider } from "./definition.js";
+import { literalUnion } from "./schema.js";
 import { getApiKeyStatus, trimSnippet } from "./shared.js";
 
 const DEFAULT_SEARCH_MODEL = "gpt-4.1";
@@ -37,6 +38,34 @@ const openaiSearchOptionsSchema = Type.Object(
           "Optional instructions that shape source selection and result style.",
       }),
     ),
+    searchContextSize: Type.Optional(
+      literalUnion(["low", "medium", "high"], {
+        description:
+          "Amount of context OpenAI web search should retrieve for each search.",
+      }),
+    ),
+    allowedDomains: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Restrict OpenAI web search to these domains.",
+      }),
+    ),
+    userLocation: Type.Optional(
+      Type.Object(
+        {
+          city: Type.Optional(Type.String({ description: "User city hint." })),
+          country: Type.Optional(
+            Type.String({ description: "Two-letter user country code." }),
+          ),
+          region: Type.Optional(
+            Type.String({ description: "User region hint." }),
+          ),
+          timezone: Type.Optional(
+            Type.String({ description: "IANA timezone hint." }),
+          ),
+        },
+        { description: "Approximate user location for OpenAI web search." },
+      ),
+    ),
   },
   { description: "OpenAI search options." },
 );
@@ -44,6 +73,9 @@ const openaiSearchOptionsSchema = Type.Object(
 const openaiSearchPromptGuidelines = [
   "Use OpenAI web search when an LLM-mediated search pass should identify likely sources from the live web.",
   "Use instructions to constrain source selection, freshness, geography, or output style only when the user explicitly needs that control.",
+  "Use allowedDomains when the user asks to search only specific sites or primary-source domains.",
+  "Use searchContextSize='high' only when the query needs richer source context; use 'low' for quick source discovery.",
+  "Use userLocation for local, regional, or jurisdiction-specific searches.",
   "Prefer web_contents after OpenAI search when the task requires direct inspection of selected primary sources.",
 ] as const;
 
@@ -60,6 +92,34 @@ const openaiAnswerOptionsSchema = Type.Object(
         description:
           "Optional instructions that shape the answer structure, tone, and source selection.",
       }),
+    ),
+    searchContextSize: Type.Optional(
+      literalUnion(["low", "medium", "high"], {
+        description:
+          "Amount of context OpenAI web search should retrieve for the grounded answer.",
+      }),
+    ),
+    allowedDomains: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Restrict OpenAI web search to these domains.",
+      }),
+    ),
+    userLocation: Type.Optional(
+      Type.Object(
+        {
+          city: Type.Optional(Type.String({ description: "User city hint." })),
+          country: Type.Optional(
+            Type.String({ description: "Two-letter user country code." }),
+          ),
+          region: Type.Optional(
+            Type.String({ description: "User region hint." }),
+          ),
+          timezone: Type.Optional(
+            Type.String({ description: "IANA timezone hint." }),
+          ),
+        },
+        { description: "Approximate user location for OpenAI web search." },
+      ),
     ),
   },
   { description: "OpenAI answer options." },
@@ -85,6 +145,34 @@ const openaiResearchOptionsSchema = Type.Object(
         description:
           "Maximum number of built-in tool calls the model may make during the research run.",
       }),
+    ),
+    searchContextSize: Type.Optional(
+      literalUnion(["low", "medium", "high"], {
+        description:
+          "Amount of context OpenAI web search should retrieve during research.",
+      }),
+    ),
+    allowedDomains: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Restrict OpenAI web search to these domains.",
+      }),
+    ),
+    userLocation: Type.Optional(
+      Type.Object(
+        {
+          city: Type.Optional(Type.String({ description: "User city hint." })),
+          country: Type.Optional(
+            Type.String({ description: "Two-letter user country code." }),
+          ),
+          region: Type.Optional(
+            Type.String({ description: "User region hint." }),
+          ),
+          timezone: Type.Optional(
+            Type.String({ description: "IANA timezone hint." }),
+          ),
+        },
+        { description: "Approximate user location for OpenAI web search." },
+      ),
     ),
   },
   { description: "OpenAI deep research options." },
@@ -338,7 +426,7 @@ function buildOpenAISearchRequest(
       "",
       `User query: ${query}`,
     ].join("\n"),
-    tools: [{ type: "web_search_preview" as const }],
+    tools: [buildOpenAIWebSearchTool(mergedOptions)],
     text: {
       format: {
         type: "json_schema" as const,
@@ -364,7 +452,7 @@ function buildOpenAIAnswerRequest(
   return {
     model,
     input: query,
-    tools: [{ type: "web_search_preview" as const }],
+    tools: [buildOpenAIWebSearchTool(mergedOptions)],
     ...(instructions ? { instructions } : {}),
   };
 }
@@ -384,10 +472,40 @@ function buildOpenAIResearchRequest(
     model,
     input,
     background: true,
-    tools: [{ type: "web_search_preview" as const }],
+    tools: [buildOpenAIWebSearchTool(mergedOptions)],
     ...(instructions ? { instructions } : {}),
     ...(maxToolCalls ? { max_tool_calls: maxToolCalls } : {}),
   };
+}
+
+function buildOpenAIWebSearchTool(
+  options: OpenAISearchOptions | OpenAIAnswerOptions | OpenAIResearchOptions,
+) {
+  const tool: {
+    type: "web_search";
+    search_context_size?: "low" | "medium" | "high";
+    filters?: { allowed_domains: string[] };
+    user_location?: {
+      type: "approximate";
+      city?: string;
+      country?: string;
+      region?: string;
+      timezone?: string;
+    };
+  } = { type: "web_search" };
+  if (options.searchContextSize) {
+    tool.search_context_size = options.searchContextSize;
+  }
+  if (options.allowedDomains && options.allowedDomains.length > 0) {
+    tool.filters = { allowed_domains: options.allowedDomains };
+  }
+  if (options.userLocation) {
+    tool.user_location = {
+      type: "approximate",
+      ...options.userLocation,
+    };
+  }
+  return tool;
 }
 
 function resolveOpenAISearchOptions(
@@ -400,10 +518,20 @@ function resolveOpenAISearchOptions(
   };
   const model = readNonEmptyString(mergedOptions.model);
   const instructions = readNonEmptyString(mergedOptions.instructions);
+  const searchContextSize = readStringUnion(mergedOptions.searchContextSize, [
+    "low",
+    "medium",
+    "high",
+  ]);
+  const allowedDomains = readStringArray(mergedOptions.allowedDomains);
+  const userLocation = readUserLocation(mergedOptions.userLocation);
 
   return {
     ...(model ? { model } : {}),
     ...(instructions ? { instructions } : {}),
+    ...(searchContextSize ? { searchContextSize } : {}),
+    ...(allowedDomains ? { allowedDomains } : {}),
+    ...(userLocation ? { userLocation } : {}),
   };
 }
 
@@ -417,10 +545,20 @@ function resolveOpenAIAnswerOptions(
   };
   const model = readNonEmptyString(mergedOptions.model);
   const instructions = readNonEmptyString(mergedOptions.instructions);
+  const searchContextSize = readStringUnion(mergedOptions.searchContextSize, [
+    "low",
+    "medium",
+    "high",
+  ]);
+  const allowedDomains = readStringArray(mergedOptions.allowedDomains);
+  const userLocation = readUserLocation(mergedOptions.userLocation);
 
   return {
     ...(model ? { model } : {}),
     ...(instructions ? { instructions } : {}),
+    ...(searchContextSize ? { searchContextSize } : {}),
+    ...(allowedDomains ? { allowedDomains } : {}),
+    ...(userLocation ? { userLocation } : {}),
   };
 }
 
@@ -435,11 +573,21 @@ function resolveOpenAIResearchOptions(
   const model = readNonEmptyString(mergedOptions.model);
   const instructions = readNonEmptyString(mergedOptions.instructions);
   const maxToolCalls = readPositiveInteger(mergedOptions.max_tool_calls);
+  const searchContextSize = readStringUnion(mergedOptions.searchContextSize, [
+    "low",
+    "medium",
+    "high",
+  ]);
+  const allowedDomains = readStringArray(mergedOptions.allowedDomains);
+  const userLocation = readUserLocation(mergedOptions.userLocation);
 
   return {
     ...(model ? { model } : {}),
     ...(instructions ? { instructions } : {}),
     ...(maxToolCalls ? { max_tool_calls: maxToolCalls } : {}),
+    ...(searchContextSize ? { searchContextSize } : {}),
+    ...(allowedDomains ? { allowedDomains } : {}),
+    ...(userLocation ? { userLocation } : {}),
   };
 }
 
@@ -674,6 +822,45 @@ function readNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0
     ? value
     : undefined;
+}
+
+function readStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const strings = value.filter(
+    (item): item is string => typeof item === "string" && item.trim() !== "",
+  );
+  return strings.length > 0 ? strings : undefined;
+}
+
+function readStringUnion<const TValue extends string>(
+  value: unknown,
+  values: readonly TValue[],
+): TValue | undefined {
+  return typeof value === "string" && values.includes(value as TValue)
+    ? (value as TValue)
+    : undefined;
+}
+
+function readUserLocation(
+  value: unknown,
+): OpenAISearchOptions["userLocation"] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const location = value as Record<string, unknown>;
+  const city = readNonEmptyString(location.city);
+  const country = readNonEmptyString(location.country);
+  const region = readNonEmptyString(location.region);
+  const timezone = readNonEmptyString(location.timezone);
+  const result = {
+    ...(city ? { city } : {}),
+    ...(country ? { country } : {}),
+    ...(region ? { region } : {}),
+    ...(timezone ? { timezone } : {}),
+  };
+  return Object.keys(result).length > 0 ? result : undefined;
 }
 
 function readPositiveInteger(value: unknown): number | undefined {

--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -7,6 +7,7 @@ import type {
   OpenAI as OpenAIConfig,
   OpenAIResearchOptions,
   OpenAISearchOptions,
+  OpenAIWebSearchToolOptions,
   ProviderCapabilityStatus,
   ProviderCapabilityStatusOptions,
   ProviderContext,
@@ -24,6 +25,38 @@ const DEFAULT_SEARCH_MODEL = "gpt-4.1";
 const DEFAULT_ANSWER_MODEL = "gpt-4.1";
 const DEFAULT_RESEARCH_MODEL = "o4-mini-deep-research";
 
+// Built-in `web_search` tool controls shared by every OpenAI capability.
+const openaiWebSearchToolProperties = {
+  searchContextSize: Type.Optional(
+    literalUnion(["low", "medium", "high"], {
+      description:
+        "Amount of context OpenAI web search should retrieve per search.",
+    }),
+  ),
+  allowedDomains: Type.Optional(
+    Type.Array(Type.String(), {
+      description: "Restrict OpenAI web search to these domains.",
+    }),
+  ),
+  userLocation: Type.Optional(
+    Type.Object(
+      {
+        city: Type.Optional(Type.String({ description: "User city hint." })),
+        country: Type.Optional(
+          Type.String({ description: "Two-letter user country code." }),
+        ),
+        region: Type.Optional(
+          Type.String({ description: "User region hint." }),
+        ),
+        timezone: Type.Optional(
+          Type.String({ description: "IANA timezone hint." }),
+        ),
+      },
+      { description: "Approximate user location for OpenAI web search." },
+    ),
+  ),
+} as const;
+
 const openaiSearchOptionsSchema = Type.Object(
   {
     model: Type.Optional(
@@ -38,34 +71,7 @@ const openaiSearchOptionsSchema = Type.Object(
           "Optional instructions that shape source selection and result style.",
       }),
     ),
-    searchContextSize: Type.Optional(
-      literalUnion(["low", "medium", "high"], {
-        description:
-          "Amount of context OpenAI web search should retrieve for each search.",
-      }),
-    ),
-    allowedDomains: Type.Optional(
-      Type.Array(Type.String(), {
-        description: "Restrict OpenAI web search to these domains.",
-      }),
-    ),
-    userLocation: Type.Optional(
-      Type.Object(
-        {
-          city: Type.Optional(Type.String({ description: "User city hint." })),
-          country: Type.Optional(
-            Type.String({ description: "Two-letter user country code." }),
-          ),
-          region: Type.Optional(
-            Type.String({ description: "User region hint." }),
-          ),
-          timezone: Type.Optional(
-            Type.String({ description: "IANA timezone hint." }),
-          ),
-        },
-        { description: "Approximate user location for OpenAI web search." },
-      ),
-    ),
+    ...openaiWebSearchToolProperties,
   },
   { description: "OpenAI search options." },
 );
@@ -93,34 +99,7 @@ const openaiAnswerOptionsSchema = Type.Object(
           "Optional instructions that shape the answer structure, tone, and source selection.",
       }),
     ),
-    searchContextSize: Type.Optional(
-      literalUnion(["low", "medium", "high"], {
-        description:
-          "Amount of context OpenAI web search should retrieve for the grounded answer.",
-      }),
-    ),
-    allowedDomains: Type.Optional(
-      Type.Array(Type.String(), {
-        description: "Restrict OpenAI web search to these domains.",
-      }),
-    ),
-    userLocation: Type.Optional(
-      Type.Object(
-        {
-          city: Type.Optional(Type.String({ description: "User city hint." })),
-          country: Type.Optional(
-            Type.String({ description: "Two-letter user country code." }),
-          ),
-          region: Type.Optional(
-            Type.String({ description: "User region hint." }),
-          ),
-          timezone: Type.Optional(
-            Type.String({ description: "IANA timezone hint." }),
-          ),
-        },
-        { description: "Approximate user location for OpenAI web search." },
-      ),
-    ),
+    ...openaiWebSearchToolProperties,
   },
   { description: "OpenAI answer options." },
 );
@@ -146,34 +125,7 @@ const openaiResearchOptionsSchema = Type.Object(
           "Maximum number of built-in tool calls the model may make during the research run.",
       }),
     ),
-    searchContextSize: Type.Optional(
-      literalUnion(["low", "medium", "high"], {
-        description:
-          "Amount of context OpenAI web search should retrieve during research.",
-      }),
-    ),
-    allowedDomains: Type.Optional(
-      Type.Array(Type.String(), {
-        description: "Restrict OpenAI web search to these domains.",
-      }),
-    ),
-    userLocation: Type.Optional(
-      Type.Object(
-        {
-          city: Type.Optional(Type.String({ description: "User city hint." })),
-          country: Type.Optional(
-            Type.String({ description: "Two-letter user country code." }),
-          ),
-          region: Type.Optional(
-            Type.String({ description: "User region hint." }),
-          ),
-          timezone: Type.Optional(
-            Type.String({ description: "IANA timezone hint." }),
-          ),
-        },
-        { description: "Approximate user location for OpenAI web search." },
-      ),
-    ),
+    ...openaiWebSearchToolProperties,
   },
   { description: "OpenAI deep research options." },
 );
@@ -478,9 +430,7 @@ function buildOpenAIResearchRequest(
   };
 }
 
-function buildOpenAIWebSearchTool(
-  options: OpenAISearchOptions | OpenAIAnswerOptions | OpenAIResearchOptions,
-) {
+function buildOpenAIWebSearchTool(options: OpenAIWebSearchToolOptions) {
   const tool: {
     type: "web_search";
     search_context_size?: "low" | "medium" | "high";
@@ -508,6 +458,23 @@ function buildOpenAIWebSearchTool(
   return tool;
 }
 
+function resolveOpenAIWebSearchToolOptions(
+  merged: Record<string, unknown>,
+): OpenAIWebSearchToolOptions {
+  const searchContextSize = readStringUnion(merged.searchContextSize, [
+    "low",
+    "medium",
+    "high",
+  ]);
+  const allowedDomains = readStringArray(merged.allowedDomains);
+  const userLocation = readUserLocation(merged.userLocation);
+  return {
+    ...(searchContextSize ? { searchContextSize } : {}),
+    ...(allowedDomains ? { allowedDomains } : {}),
+    ...(userLocation ? { userLocation } : {}),
+  };
+}
+
 function resolveOpenAISearchOptions(
   config: OpenAIConfig,
   options?: Record<string, unknown>,
@@ -518,20 +485,11 @@ function resolveOpenAISearchOptions(
   };
   const model = readNonEmptyString(mergedOptions.model);
   const instructions = readNonEmptyString(mergedOptions.instructions);
-  const searchContextSize = readStringUnion(mergedOptions.searchContextSize, [
-    "low",
-    "medium",
-    "high",
-  ]);
-  const allowedDomains = readStringArray(mergedOptions.allowedDomains);
-  const userLocation = readUserLocation(mergedOptions.userLocation);
 
   return {
     ...(model ? { model } : {}),
     ...(instructions ? { instructions } : {}),
-    ...(searchContextSize ? { searchContextSize } : {}),
-    ...(allowedDomains ? { allowedDomains } : {}),
-    ...(userLocation ? { userLocation } : {}),
+    ...resolveOpenAIWebSearchToolOptions(mergedOptions),
   };
 }
 
@@ -545,20 +503,11 @@ function resolveOpenAIAnswerOptions(
   };
   const model = readNonEmptyString(mergedOptions.model);
   const instructions = readNonEmptyString(mergedOptions.instructions);
-  const searchContextSize = readStringUnion(mergedOptions.searchContextSize, [
-    "low",
-    "medium",
-    "high",
-  ]);
-  const allowedDomains = readStringArray(mergedOptions.allowedDomains);
-  const userLocation = readUserLocation(mergedOptions.userLocation);
 
   return {
     ...(model ? { model } : {}),
     ...(instructions ? { instructions } : {}),
-    ...(searchContextSize ? { searchContextSize } : {}),
-    ...(allowedDomains ? { allowedDomains } : {}),
-    ...(userLocation ? { userLocation } : {}),
+    ...resolveOpenAIWebSearchToolOptions(mergedOptions),
   };
 }
 
@@ -573,21 +522,12 @@ function resolveOpenAIResearchOptions(
   const model = readNonEmptyString(mergedOptions.model);
   const instructions = readNonEmptyString(mergedOptions.instructions);
   const maxToolCalls = readPositiveInteger(mergedOptions.max_tool_calls);
-  const searchContextSize = readStringUnion(mergedOptions.searchContextSize, [
-    "low",
-    "medium",
-    "high",
-  ]);
-  const allowedDomains = readStringArray(mergedOptions.allowedDomains);
-  const userLocation = readUserLocation(mergedOptions.userLocation);
 
   return {
     ...(model ? { model } : {}),
     ...(instructions ? { instructions } : {}),
     ...(maxToolCalls ? { max_tool_calls: maxToolCalls } : {}),
-    ...(searchContextSize ? { searchContextSize } : {}),
-    ...(allowedDomains ? { allowedDomains } : {}),
-    ...(userLocation ? { userLocation } : {}),
+    ...resolveOpenAIWebSearchToolOptions(mergedOptions),
   };
 }
 

--- a/src/providers/schema.ts
+++ b/src/providers/schema.ts
@@ -9,3 +9,14 @@ export function literalUnion<const TValues extends readonly string[]>(
     options,
   );
 }
+
+/**
+ * A flag that can be enabled with `true` or configured with an options object.
+ * Common for SDK tool toggles that also accept per-tool configuration.
+ */
+export function boolOrConfig(options?: Record<string, unknown>) {
+  return Type.Union(
+    [Type.Boolean(), Type.Record(Type.String(), Type.Any())],
+    options,
+  );
+}

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -15,7 +15,7 @@ import type {
   Valyu,
 } from "../types.js";
 import { defineCapability, defineProvider } from "./definition.js";
-import { literalUnion } from "./schema.js";
+import { boolOrConfig, literalUnion } from "./schema.js";
 import {
   asJsonObject,
   formatJson,
@@ -264,30 +264,10 @@ const valyuResearchOptionsSchema = Type.Object(
     tools: Type.Optional(
       Type.Object(
         {
-          code_execution: Type.Optional(
-            Type.Union([
-              Type.Boolean(),
-              Type.Record(Type.String(), Type.Any()),
-            ]),
-          ),
-          screenshots: Type.Optional(
-            Type.Union([
-              Type.Boolean(),
-              Type.Record(Type.String(), Type.Any()),
-            ]),
-          ),
-          browser_use: Type.Optional(
-            Type.Union([
-              Type.Boolean(),
-              Type.Record(Type.String(), Type.Any()),
-            ]),
-          ),
-          charts: Type.Optional(
-            Type.Union([
-              Type.Boolean(),
-              Type.Record(Type.String(), Type.Any()),
-            ]),
-          ),
+          code_execution: Type.Optional(boolOrConfig()),
+          screenshots: Type.Optional(boolOrConfig()),
+          browser_use: Type.Optional(boolOrConfig()),
+          charts: Type.Optional(boolOrConfig()),
         },
         {
           additionalProperties: false,

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -222,11 +222,6 @@ const valyuResearchOptionsSchema = Type.Object(
         description: "Valyu deep research mode.",
       }),
     ),
-    model: Type.Optional(
-      literalUnion(["fast", "standard", "lite", "heavy", "max"], {
-        description: "Valyu deep research model.",
-      }),
-    ),
     outputFormats: Type.Optional(
       Type.Array(
         Type.Union([

--- a/src/providers/valyu.ts
+++ b/src/providers/valyu.ts
@@ -62,6 +62,11 @@ const valyuSearchOptionsSchema = Type.Object(
         description: "Exclude these Valyu sources.",
       }),
     ),
+    sourceBiases: Type.Optional(
+      Type.Record(Type.String(), Type.Number(), {
+        description: "Per-source relevance bias weights.",
+      }),
+    ),
     category: Type.Optional(
       Type.String({ description: "Valyu source category to search." }),
     ),
@@ -70,6 +75,11 @@ const valyuSearchOptionsSchema = Type.Object(
     ),
     endDate: Type.Optional(
       Type.String({ description: "ISO date string for latest result date." }),
+    ),
+    historicalCache: Type.Optional(
+      Type.Boolean({
+        description: "Allow Valyu historical cache usage when supported.",
+      }),
     ),
     fastMode: Type.Optional(
       Type.Boolean({
@@ -137,19 +147,69 @@ const valyuContentsOptionsSchema = Type.Object(
         description: "Include screenshot capture when supported.",
       }),
     ),
+    startDate: Type.Optional(
+      Type.String({
+        description: "ISO date string for earliest content date.",
+      }),
+    ),
+    endDate: Type.Optional(
+      Type.String({ description: "ISO date string for latest content date." }),
+    ),
+    historicalCache: Type.Optional(
+      Type.Boolean({
+        description: "Allow Valyu historical cache usage when supported.",
+      }),
+    ),
   },
   { description: "Valyu contents options." },
 );
 
 const valyuAnswerOptionsSchema = Type.Object(
   {
-    responseLength: Type.Optional(
-      literalUnion(["short", "medium", "large", "max"], {
-        description: "Response length for answers.",
+    structuredOutput: Type.Optional(
+      Type.Record(Type.String(), Type.Any(), {
+        description: "JSON schema-like structured output specification.",
+      }),
+    ),
+    systemInstructions: Type.Optional(
+      Type.String({
+        description: "System instructions that guide Valyu answer generation.",
+      }),
+    ),
+    searchType: Type.Optional(
+      literalUnion(["all", "web", "proprietary", "news"], {
+        description: "Valyu search type for answer grounding.",
+      }),
+    ),
+    dataMaxPrice: Type.Optional(
+      Type.Number({
+        minimum: 0,
+        description: "Maximum data retrieval price for answer grounding.",
       }),
     ),
     countryCode: Type.Optional(
       Type.String({ description: "Country code to scope answer results." }),
+    ),
+    includedSources: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Restrict answer grounding to these Valyu sources.",
+      }),
+    ),
+    excludedSources: Type.Optional(
+      Type.Array(Type.String(), {
+        description: "Exclude these Valyu sources from answer grounding.",
+      }),
+    ),
+    startDate: Type.Optional(
+      Type.String({ description: "ISO date string for earliest source date." }),
+    ),
+    endDate: Type.Optional(
+      Type.String({ description: "ISO date string for latest source date." }),
+    ),
+    fastMode: Type.Optional(
+      Type.Boolean({
+        description: "Use Valyu fast mode when lower latency is preferred.",
+      }),
     ),
   },
   { description: "Valyu answer options." },
@@ -157,13 +217,83 @@ const valyuAnswerOptionsSchema = Type.Object(
 
 const valyuResearchOptionsSchema = Type.Object(
   {
-    responseLength: Type.Optional(
-      literalUnion(["short", "medium", "large", "max"], {
-        description: "Response length for research.",
+    mode: Type.Optional(
+      literalUnion(["fast", "standard", "lite", "heavy", "max"], {
+        description: "Valyu deep research mode.",
       }),
     ),
-    countryCode: Type.Optional(
-      Type.String({ description: "Country code to scope research results." }),
+    model: Type.Optional(
+      literalUnion(["fast", "standard", "lite", "heavy", "max"], {
+        description: "Valyu deep research model.",
+      }),
+    ),
+    outputFormats: Type.Optional(
+      Type.Array(
+        Type.Union([
+          literalUnion(["markdown", "pdf", "toon"]),
+          Type.Record(Type.String(), Type.Any()),
+        ]),
+        { description: "Requested Valyu research output formats." },
+      ),
+    ),
+    search: Type.Optional(
+      Type.Object(
+        {
+          searchType: Type.Optional(
+            literalUnion(["all", "web", "proprietary"], {
+              description: "Valyu source pool for research.",
+            }),
+          ),
+          includedSources: Type.Optional(Type.Array(Type.String())),
+          excludedSources: Type.Optional(Type.Array(Type.String())),
+          sourceBiases: Type.Optional(
+            Type.Record(Type.String(), Type.Number()),
+          ),
+          startDate: Type.Optional(Type.String()),
+          endDate: Type.Optional(Type.String()),
+          historicalCache: Type.Optional(Type.Boolean()),
+          category: Type.Optional(Type.String()),
+          countryCode: Type.Optional(Type.String()),
+        },
+        {
+          additionalProperties: false,
+          description: "Valyu deep research search configuration.",
+        },
+      ),
+    ),
+    tools: Type.Optional(
+      Type.Object(
+        {
+          code_execution: Type.Optional(
+            Type.Union([
+              Type.Boolean(),
+              Type.Record(Type.String(), Type.Any()),
+            ]),
+          ),
+          screenshots: Type.Optional(
+            Type.Union([
+              Type.Boolean(),
+              Type.Record(Type.String(), Type.Any()),
+            ]),
+          ),
+          browser_use: Type.Optional(
+            Type.Union([
+              Type.Boolean(),
+              Type.Record(Type.String(), Type.Any()),
+            ]),
+          ),
+          charts: Type.Optional(
+            Type.Union([
+              Type.Boolean(),
+              Type.Record(Type.String(), Type.Any()),
+            ]),
+          ),
+        },
+        {
+          additionalProperties: false,
+          description: "Valyu deep research tool configuration.",
+        },
+      ),
     ),
   },
   { description: "Valyu research options." },

--- a/src/types.ts
+++ b/src/types.ts
@@ -306,7 +306,6 @@ export interface ValyuAnswerOptions extends Record<string, unknown> {
 
 export interface ValyuResearchOptions extends Record<string, unknown> {
   mode?: "fast" | "standard" | "lite" | "heavy" | "max";
-  model?: "fast" | "standard" | "lite" | "heavy" | "max";
   outputFormats?: Array<"markdown" | "pdf" | "toon" | Record<string, unknown>>;
   search?: {
     searchType?: "all" | "web" | "proprietary";

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,9 +165,8 @@ export interface ParallelOptions {
   extract?: Record<string, unknown>;
 }
 
-export interface OpenAISearchOptions {
-  model?: string;
-  instructions?: string;
+// Built-in `web_search` tool controls shared by every OpenAI capability.
+export interface OpenAIWebSearchToolOptions {
   searchContextSize?: "low" | "medium" | "high";
   allowedDomains?: string[];
   userLocation?: {
@@ -178,31 +177,20 @@ export interface OpenAISearchOptions {
   };
 }
 
-export interface OpenAIAnswerOptions {
+export interface OpenAISearchOptions extends OpenAIWebSearchToolOptions {
   model?: string;
   instructions?: string;
-  searchContextSize?: "low" | "medium" | "high";
-  allowedDomains?: string[];
-  userLocation?: {
-    city?: string;
-    country?: string;
-    region?: string;
-    timezone?: string;
-  };
 }
 
-export interface OpenAIResearchOptions {
+export interface OpenAIAnswerOptions extends OpenAIWebSearchToolOptions {
+  model?: string;
+  instructions?: string;
+}
+
+export interface OpenAIResearchOptions extends OpenAIWebSearchToolOptions {
   model?: string;
   instructions?: string;
   max_tool_calls?: number;
-  searchContextSize?: "low" | "medium" | "high";
-  allowedDomains?: string[];
-  userLocation?: {
-    city?: string;
-    country?: string;
-    region?: string;
-    timezone?: string;
-  };
 }
 
 export interface OpenAIOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,17 +168,41 @@ export interface ParallelOptions {
 export interface OpenAISearchOptions {
   model?: string;
   instructions?: string;
+  searchContextSize?: "low" | "medium" | "high";
+  allowedDomains?: string[];
+  userLocation?: {
+    city?: string;
+    country?: string;
+    region?: string;
+    timezone?: string;
+  };
 }
 
 export interface OpenAIAnswerOptions {
   model?: string;
   instructions?: string;
+  searchContextSize?: "low" | "medium" | "high";
+  allowedDomains?: string[];
+  userLocation?: {
+    city?: string;
+    country?: string;
+    region?: string;
+    timezone?: string;
+  };
 }
 
 export interface OpenAIResearchOptions {
   model?: string;
   instructions?: string;
   max_tool_calls?: number;
+  searchContextSize?: "low" | "medium" | "high";
+  allowedDomains?: string[];
+  userLocation?: {
+    city?: string;
+    country?: string;
+    region?: string;
+    timezone?: string;
+  };
 }
 
 export interface OpenAIOptions {
@@ -262,6 +286,7 @@ export interface ValyuSearchOptions extends Record<string, unknown> {
   category?: string;
   startDate?: string;
   endDate?: string;
+  historicalCache?: boolean;
   fastMode?: boolean;
   urlOnly?: boolean;
   instructions?: string;
@@ -273,13 +298,17 @@ export interface ValyuContentsOptions extends Record<string, unknown> {
   responseLength?: "short" | "medium" | "large" | "max" | number;
   maxPriceDollars?: number;
   screenshot?: boolean;
+  startDate?: string;
+  endDate?: string;
+  historicalCache?: boolean;
 }
 
 export interface ValyuAnswerOptions extends Record<string, unknown> {
-  responseLength?: "short" | "medium" | "large" | "max" | number;
-  countryCode?: string;
+  structuredOutput?: Record<string, unknown>;
+  systemInstructions?: string;
   searchType?: "all" | "web" | "proprietary" | "news";
   dataMaxPrice?: number;
+  countryCode?: string;
   includedSources?: string[];
   excludedSources?: string[];
   startDate?: string;
@@ -288,8 +317,26 @@ export interface ValyuAnswerOptions extends Record<string, unknown> {
 }
 
 export interface ValyuResearchOptions extends Record<string, unknown> {
-  responseLength?: "short" | "medium" | "large" | "max";
-  countryCode?: string;
+  mode?: "fast" | "standard" | "lite" | "heavy" | "max";
+  model?: "fast" | "standard" | "lite" | "heavy" | "max";
+  outputFormats?: Array<"markdown" | "pdf" | "toon" | Record<string, unknown>>;
+  search?: {
+    searchType?: "all" | "web" | "proprietary";
+    includedSources?: string[];
+    excludedSources?: string[];
+    sourceBiases?: Record<string, number>;
+    startDate?: string;
+    endDate?: string;
+    historicalCache?: boolean;
+    category?: string;
+    countryCode?: string;
+  };
+  tools?: {
+    code_execution?: boolean | Record<string, unknown>;
+    screenshots?: boolean | Record<string, unknown>;
+    browser_use?: boolean | Record<string, unknown>;
+    charts?: boolean | Record<string, unknown>;
+  };
 }
 
 export interface ValyuOptions {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -291,15 +291,24 @@ describe("config parsing", () => {
             options: {
               search: {
                 searchType: "all",
+                sourceBiases: {
+                  web: 0.5,
+                },
               },
               answer: {
-                responseLength: "medium",
+                searchType: "web",
+                includedSources: ["web"],
               },
               contents: {
                 responseLength: "medium",
+                historicalCache: true,
               },
               research: {
-                responseLength: "large",
+                mode: "heavy",
+                search: {
+                  searchType: "proprietary",
+                  historicalCache: true,
+                },
               },
             },
           },
@@ -313,15 +322,24 @@ describe("config parsing", () => {
       options: {
         search: {
           searchType: "all",
+          sourceBiases: {
+            web: 0.5,
+          },
         },
         answer: {
-          responseLength: "medium",
+          searchType: "web",
+          includedSources: ["web"],
         },
         contents: {
           responseLength: "medium",
+          historicalCache: true,
         },
         research: {
-          responseLength: "large",
+          mode: "heavy",
+          search: {
+            searchType: "proprietary",
+            historicalCache: true,
+          },
         },
       },
     });

--- a/test/research-lifecycle-providers.test.ts
+++ b/test/research-lifecycle-providers.test.ts
@@ -115,6 +115,12 @@ describe("OpenAI provider", () => {
       onUpdate: undefined,
       options: {
         instructions: "Prefer official sources.",
+        allowedDomains: ["platform.openai.com"],
+        searchContextSize: "high",
+        userLocation: {
+          country: "US",
+          region: "California",
+        },
       },
       maxResults: 3,
       queries: ["openai deep research"],
@@ -136,7 +142,18 @@ describe("OpenAI provider", () => {
           "",
           "User query: openai deep research",
         ].join("\n"),
-        tools: [{ type: "web_search_preview" }],
+        tools: [
+          {
+            type: "web_search",
+            filters: { allowed_domains: ["platform.openai.com"] },
+            search_context_size: "high",
+            user_location: {
+              type: "approximate",
+              country: "US",
+              region: "California",
+            },
+          },
+        ],
         text: {
           format: {
             type: "json_schema",
@@ -248,7 +265,7 @@ describe("OpenAI provider", () => {
       {
         model: "gpt-4.1",
         input: "What is the latest OpenAI deep research API?",
-        tools: [{ type: "web_search_preview" }],
+        tools: [{ type: "web_search" }],
         instructions: "Keep the answer concise and prefer primary sources.",
       },
       expect.objectContaining({
@@ -379,7 +396,7 @@ describe("async research providers", () => {
         model: "o3-deep-research",
         input: "Investigate OpenAI deep research polling",
         background: true,
-        tools: [{ type: "web_search_preview" }],
+        tools: [{ type: "web_search" }],
         instructions: "Prefer primary sources.",
         max_tool_calls: 12,
       },

--- a/test/tool-availability.test.ts
+++ b/test/tool-availability.test.ts
@@ -389,10 +389,11 @@ describe("managed tool availability", () => {
     expect(exaOptions.additionalProperties).toBe(false);
     expect(exaOptions.properties).not.toHaveProperty("provider");
     expect(exaOptions.properties).not.toHaveProperty("runtime");
-    expect(exaOptions.properties?.userLocation?.additionalProperties).toBe(
-      false,
-    );
+    expect(exaOptions.properties).toHaveProperty("userLocation");
     expect(JSON.stringify(exaOptions)).toContain("includeDomains");
+    expect(JSON.stringify(exaOptions)).toContain("startCrawlDate");
+    expect(JSON.stringify(exaOptions)).toContain("maxAgeHours");
+    expect(JSON.stringify(exaOptions)).not.toContain("deep-max");
     expect(JSON.stringify(exaOptions)).not.toContain("gl");
     expect(
       (webSearch?.parameters?.properties?.maxResults as { maximum?: number })


### PR DESCRIPTION
## 🔍 Problem

- The SDK lockfile resolved older provider clients for Bun installs.
- Some provider option schemas lagged the latest useful SDK surface, while a few no-longer-supported options were still advertised.

## 🛠️ Solution

- Refresh Bun SDK resolutions for the provider clients.
- Expose current OpenAI, Exa, Firecrawl, and Valyu provider options where they fit the managed web tools.
- Stop advertising unsupported Exa and Valyu options.
- Update README, changelog, and tests for the new surface.

## 💬 Review

- Focus on whether the newly exposed options are useful without overfitting to provider internals.
- OpenAI now uses the current `web_search` Responses tool instead of `web_search_preview`.
