### PR TITLE
Render progress glyphs with muted color

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ or, on Windows, `APPDATA`. Override it with `WEBFOX_CONFIG` or `--config <path>`
 For example:
 
 ```yaml
-$schema: https://unpkg.com/webfox@3.5.1/dist/config.schema.json
+$schema: https://unpkg.com/webfox@4.0.0/dist/config.schema.json
 defaults:
   search:
     provider: brave

--- a/changelog/unreleased/neutral-progress-glyph-color.md
+++ b/changelog/unreleased/neutral-progress-glyph-color.md
@@ -1,0 +1,9 @@
+---
+title: Neutral progress glyph color
+type: bugfix
+authors:
+  - mavam
+created: 2026-09-07T15:34:02.710945Z
+---
+
+The pi extension now renders the active progress glyph in the muted color instead of the warning color, keeping in-progress web requests visually neutral.

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,4 +1,4 @@
-$schema: https://unpkg.com/webfox@3.5.1/dist/config.schema.json
+$schema: https://unpkg.com/webfox@4.0.0/dist/config.schema.json
 defaults:
   search:
     provider: brave

--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://unpkg.com/webfox@3.5.1/dist/config.schema.json",
+  "$id": "https://unpkg.com/webfox@4.0.0/dist/config.schema.json",
   "title": "webfox configuration",
   "type": "object",
   "additionalProperties": false,

--- a/src/pi-render.ts
+++ b/src/pi-render.ts
@@ -16,7 +16,7 @@ import { renderSearchResult } from "./pi-search-render.js";
 
 const inputStates = {
   queued: { glyph: "●", color: "dim" },
-  running: { glyph: "▶︎", color: "warning" },
+  running: { glyph: "▶︎", color: "muted" },
   done: { glyph: "✔︎", color: "success" },
   failed: { glyph: "✘︎", color: "error" },
   cancelled: { glyph: "■", color: "dim" },

--- a/test/pi-render.test.ts
+++ b/test/pi-render.test.ts
@@ -267,7 +267,7 @@ describe("vertical web rendering", () => {
     ]);
     for (const [color, glyph] of [
       ["dim", "●"],
-      ["warning", "▶︎"],
+      ["muted", "▶︎"],
       ["success", "✔︎"],
       ["error", "✘︎"],
       ["dim", "■"],
@@ -383,7 +383,7 @@ describe("vertical web rendering", () => {
         false,
       ).render(80),
     ).toEqual(["▶︎ Working…"]);
-    expect(progressTheme.fg).toHaveBeenCalledWith("warning", "▶︎");
+    expect(progressTheme.fg).toHaveBeenCalledWith("muted", "▶︎");
     expect(progressTheme.fg).toHaveBeenCalledWith("muted", "Working…");
     const legacy = { content: [{ type: "text", text: "# Legacy heading" }] };
     expect(


### PR DESCRIPTION
## 🔍 Problem

The active `▶︎` progress glyph uses the warning color, making normal in-progress web requests look cautionary.

The v4.0.0 release also left static schema links pointing at v3.5.1, which causes the package metadata test to fail after the release version bump.

## 🛠️ Solution

- Render active progress glyphs with the neutral muted color.
- Align static schema links with v4.0.0.
- Cover the progress color in rendering tests and document the fix in the changelog.

## 💬 Review

The behavior change is limited to the pi extension's progress glyph styling.
