### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/.github/workflows/live-smoke.yaml
+++ b/.github/workflows/live-smoke.yaml
@@ -73,6 +73,7 @@ jobs:
           SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           VALYU_API_KEY: ${{ secrets.VALYU_API_KEY }}
+          YDC_API_KEY: ${{ secrets.YDC_API_KEY }}
         run: |
           args=(--provider "$PROVIDER" --capability "$CAPABILITY" --options-json "$PROVIDER_OPTIONS")
           if [[ "$INCLUDE_RESEARCH" == "true" ]]; then

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Use different providers for different tasks:
 | [Serper]     |   ✔︎    |          |        |          |
 | [Tavily]     |   ✔︎    |    ✔︎     |        |          |
 | [Valyu]      |   ✔︎    |    ✔︎     |   ✔︎    |    ✔︎     |
+| [You.com]    |   ✔︎    |          |        |          |
 
 [Brave]: ./docs/provider.md#brave
 [Cloudflare]: ./docs/provider.md#cloudflare
@@ -152,6 +153,7 @@ Use different providers for different tasks:
 [Serper]: ./docs/provider.md#serper
 [Tavily]: ./docs/provider.md#tavily
 [Valyu]: ./docs/provider.md#valyu
+[You.com]: ./docs/provider.md#youcom
 
 See the [provider guide](./docs/provider.md) for credentials, examples, and caveats.
 
@@ -172,7 +174,7 @@ or, on Windows, `APPDATA`. Override it with `WEBFOX_CONFIG` or `--config <path>`
 For example:
 
 ```yaml
-$schema: https://unpkg.com/webfox@4.0.0/dist/config.schema.json
+$schema: https://unpkg.com/webfox@4.0.1/dist/config.schema.json
 defaults:
   search:
     provider: brave

--- a/changelog/unreleased/youcom-web-and-news-search.md
+++ b/changelog/unreleased/youcom-web-and-news-search.md
@@ -1,0 +1,17 @@
+---
+title: You.com web and news search
+type: feature
+authors:
+  - mavam
+prs:
+  - 40
+created: 2026-09-07T17:53:35.426084Z
+---
+
+You can now use You.com for web and news search from the CLI, TypeScript library, and Pi extension. Set `YDC_API_KEY` and select the provider:
+
+```sh
+web search "Node.js release notes" --provider youcom --freshness week
+```
+
+Results alternate between web and news within the requested result limit. Provider options support domain filtering and boosting, country and language selection, pagination, and optional live crawling for full HTML or Markdown content. Live crawling adds latency and per-page charges. Existing provider defaults remain unchanged.

--- a/changelog/unreleased/youcom-web-and-news-search.md
+++ b/changelog/unreleased/youcom-web-and-news-search.md
@@ -2,10 +2,10 @@
 title: You.com web and news search
 type: feature
 authors:
-  - mavam
+  - mouse-value-add
 prs:
   - 40
-created: 2026-09-07T17:53:35.426084Z
+created: 2026-09-07T17:56:46.54333Z
 ---
 
 You can now use You.com for web and news search from the CLI, TypeScript library, and Pi extension. Set `YDC_API_KEY` and select the provider:

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -162,13 +162,81 @@ web search "Node.js release notes" --provider serper
 
 ## You.com
 
-Supports search with unified web and news results. Set `YDC_API_KEY`.
+Supports search. Set `YDC_API_KEY`; the library, CLI, and Pi extension use the
+same credential. No defaults change unless you select You.com.
 
 ```sh
-web search "Node.js release notes" --provider youcom
+web search "Node.js release notes" --provider youcom \
+  --freshness week --country US --language EN --include-domains nodejs.org
+web config default search youcom
 ```
 
-Use `include_domains` or `exclude_domains` to focus a search on a known source set, and use `extraction.extraction_mode = "highlights"` when you want query-aware passages for RAG-style workflows.
+You.com returns separate web and news sections. Webfox alternates results from
+these sections, starting with web and preserving each section's order, up to
+`maxResults` (capped at 100 overall). If one section is exhausted, the other fills
+the remaining slots. With `maxResults: 1`, web takes precedence. The `offset`
+option selects pages from each section independently, using the capped
+`maxResults` as the upstream page size.
+
+Use `include_domains` to restrict sources, or combine `exclude_domains` with
+`boost_domains` to exclude some sources and favor others. Don't combine
+`include_domains` with either of the other domain lists. Each list supports up to
+500 domains. Country and language codes use the API's uppercase spelling, such
+as `US`, `EN`, and `EN-GB`. Run `web search --provider youcom --help` for supported
+values and all native options.
+
+Search snippets already contain query-relevant passages. For full page content,
+enable live crawling:
+
+```sh
+web search "Node.js cancellation" --provider youcom \
+  --livecrawl web --livecrawl-formats markdown --crawl-timeout 10 --format json
+```
+
+Live crawling adds latency and per-page charges, including pages that don't fit
+within the final result limit. By default, it returns HTML; request `markdown` or
+both formats as needed. Full content is preserved in each result's
+`metadata.contents`; text output shows snippets rather than full pages. See
+[You.com's API reference](https://you.com/docs/api-reference/search/v1-search-post)
+for current pricing and filter behavior.
+
+Provider-specific defaults belong under `providers.youcom.options.search`:
+
+```yaml
+defaults:
+  search:
+    provider: youcom
+providers:
+  youcom:
+    options:
+      search:
+        country: US
+        language: EN
+        safesearch: moderate
+```
+
+`providers.youcom.baseUrl` optionally replaces the API origin for a proxy; webfox
+appends `/v1/search`. Credential overrides use `providers.youcom.credentials.api`.
+For example, `{env: MY_YOUCOM_KEY}` selects another environment variable.
+
+The TypeScript library accepts the same native option names:
+
+```ts
+import { createWebfox } from "webfox";
+
+const result = await createWebfox().search({
+  provider: "youcom",
+  queries: ["Node.js release notes"],
+  maxResults: 5,
+  options: { freshness: "week", include_domains: ["nodejs.org"] },
+});
+```
+
+The provider uses the JSON POST API directly, like the HTTP-based Brave and
+Serper providers. Option names follow the wire contract rather than the official
+You.com SDK's camelCase names. Selecting You.com as the search default exposes
+these options through the existing `web_search` Pi tool; no separate tool is
+needed.
 
 ## Tavily
 

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -160,6 +160,16 @@ Supports search. Set `SERPER_API_KEY`.
 web search "Node.js release notes" --provider serper
 ```
 
+## You.com
+
+Supports search with unified web and news results. Set `YDC_API_KEY`.
+
+```sh
+web search "Node.js release notes" --provider youcom
+```
+
+Use `include_domains` or `exclude_domains` to focus a search on a known source set, and use `extraction.extraction_mode = "highlights"` when you want query-aware passages for RAG-style workflows.
+
 ## Tavily
 
 Supports search and page extraction. Set `TAVILY_API_KEY`.

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -34,3 +34,11 @@ providers:
     credentials:
       api:
         env: GOOGLE_API_KEY
+  youcom:
+    credentials:
+      api:
+        env: YDC_API_KEY
+    options:
+      search:
+        language: EN
+        safesearch: moderate

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,4 +1,4 @@
-$schema: https://unpkg.com/webfox@4.0.0/dist/config.schema.json
+$schema: https://unpkg.com/webfox@4.0.1/dist/config.schema.json
 defaults:
   search:
     provider: brave

--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://unpkg.com/webfox@4.0.0/dist/config.schema.json",
+  "$id": "https://unpkg.com/webfox@4.0.1/dist/config.schema.json",
   "title": "webfox configuration",
   "type": "object",
   "additionalProperties": false,
@@ -30,7 +30,8 @@
                 "perplexity",
                 "serper",
                 "tavily",
-                "valyu"
+                "valyu",
+                "youcom"
               ]
             },
             "maxResults": {
@@ -4258,6 +4259,142 @@
                     }
                   },
                   "description": "Valyu research options.",
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "youcom": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "credentials": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "api": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": ["env"]
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": ["value"]
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "command": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        }
+                      },
+                      "required": ["command"]
+                    }
+                  ]
+                }
+              }
+            },
+            "baseUrl": {
+              "type": "string",
+              "minLength": 1
+            },
+            "options": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "search": {
+                  "type": "object",
+                  "properties": {
+                    "freshness": {
+                      "type": "string",
+                      "description": "Freshness window such as day, week, month, year, or a YYYY-MM-DDtoYYYY-MM-DD range."
+                    },
+                    "country": {
+                      "type": "string",
+                      "description": "Country code used to localize search results, for example US."
+                    },
+                    "language": {
+                      "type": "string",
+                      "description": "Language for the returned web results, for example en."
+                    },
+                    "safesearch": {
+                      "type": "string",
+                      "enum": ["moderate", "off", "strict"],
+                      "description": "Safe-search filtering level."
+                    },
+                    "knowledge": {
+                      "type": "boolean",
+                      "description": "Include knowledge results alongside web and news results."
+                    },
+                    "offset": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 9,
+                      "description": "Pagination offset. Results are returned in count-sized pages."
+                    },
+                    "include_domains": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Allowlist of domains to return from You.com search results."
+                    },
+                    "exclude_domains": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Blocklist of domains to exclude from You.com search results."
+                    },
+                    "boost_domains": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Domains to boost in ranking without filtering out other results."
+                    },
+                    "extraction": {
+                      "type": "object",
+                      "properties": {
+                        "extraction_mode": {
+                          "type": "string",
+                          "enum": ["highlights", "full_page"],
+                          "description": "Request query-aware highlights or full-page content for each result."
+                        },
+                        "crawl_timeout": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 60,
+                          "description": "Seconds to wait while crawling pages for extraction."
+                        }
+                      },
+                      "description": "Optional extraction controls for the You.com Search API POST endpoint.",
+                      "additionalProperties": false
+                    }
+                  },
+                  "description": "You.com search options.",
                   "additionalProperties": false
                 }
               }

--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -4329,72 +4329,182 @@
                   "properties": {
                     "freshness": {
                       "type": "string",
-                      "description": "Freshness window such as day, week, month, year, or a YYYY-MM-DDtoYYYY-MM-DD range."
+                      "description": "Freshness window: day, week, month, year, or YYYY-MM-DDtoYYYY-MM-DD. You.com uses the broader timeframe when the query also specifies one."
                     },
                     "country": {
                       "type": "string",
+                      "enum": [
+                        "AR",
+                        "AU",
+                        "AT",
+                        "BE",
+                        "BR",
+                        "CA",
+                        "CL",
+                        "DK",
+                        "FI",
+                        "FR",
+                        "DE",
+                        "HK",
+                        "IN",
+                        "ID",
+                        "IT",
+                        "JP",
+                        "KR",
+                        "MY",
+                        "MX",
+                        "NL",
+                        "NZ",
+                        "NO",
+                        "CN",
+                        "PL",
+                        "PT",
+                        "PH",
+                        "RU",
+                        "SA",
+                        "ZA",
+                        "ES",
+                        "SE",
+                        "CH",
+                        "TW",
+                        "TR",
+                        "GB",
+                        "US"
+                      ],
                       "description": "Country code used to localize search results, for example US."
                     },
                     "language": {
                       "type": "string",
-                      "description": "Language for the returned web results, for example en."
+                      "enum": [
+                        "AR",
+                        "EU",
+                        "BN",
+                        "BG",
+                        "CA",
+                        "ZH-HANS",
+                        "ZH-HANT",
+                        "HR",
+                        "CS",
+                        "DA",
+                        "NL",
+                        "EN",
+                        "EN-GB",
+                        "ET",
+                        "FI",
+                        "FR",
+                        "GL",
+                        "DE",
+                        "EL",
+                        "GU",
+                        "HE",
+                        "HI",
+                        "HU",
+                        "IS",
+                        "IT",
+                        "JA",
+                        "KN",
+                        "KO",
+                        "LV",
+                        "LT",
+                        "MS",
+                        "ML",
+                        "MR",
+                        "NB",
+                        "PL",
+                        "PT-BR",
+                        "PT-PT",
+                        "PA",
+                        "RO",
+                        "RU",
+                        "SR",
+                        "SK",
+                        "SL",
+                        "ES",
+                        "SV",
+                        "TA",
+                        "TE",
+                        "TH",
+                        "TR",
+                        "UK",
+                        "VI"
+                      ],
+                      "description": "Language of web results. Uses You.com's uppercase codes; defaults to EN."
                     },
                     "safesearch": {
                       "type": "string",
                       "enum": ["moderate", "off", "strict"],
-                      "description": "Safe-search filtering level."
-                    },
-                    "knowledge": {
-                      "type": "boolean",
-                      "description": "Include knowledge results alongside web and news results."
+                      "description": "Safe-search filtering level. Defaults to moderate."
                     },
                     "offset": {
                       "type": "integer",
                       "minimum": 0,
                       "maximum": 9,
-                      "description": "Pagination offset. Results are returned in count-sized pages."
+                      "description": "Pagination offset in count-sized pages, separately for web and news. Count is maxResults capped at 100."
                     },
                     "include_domains": {
                       "type": "array",
+                      "maxItems": 500,
                       "items": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                       },
-                      "description": "Allowlist of domains to return from You.com search results."
+                      "description": "Restrict results to these domains. Cannot be combined with exclude_domains or boost_domains."
                     },
                     "exclude_domains": {
                       "type": "array",
+                      "maxItems": 500,
                       "items": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                       },
-                      "description": "Blocklist of domains to exclude from You.com search results."
+                      "description": "Exclude these domains. Cannot be combined with include_domains."
                     },
                     "boost_domains": {
                       "type": "array",
+                      "maxItems": 500,
                       "items": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                       },
-                      "description": "Domains to boost in ranking without filtering out other results."
+                      "description": "Boost these domains without excluding others. Can be combined with exclude_domains, but not include_domains."
                     },
-                    "extraction": {
-                      "type": "object",
-                      "properties": {
-                        "extraction_mode": {
-                          "type": "string",
-                          "enum": ["highlights", "full_page"],
-                          "description": "Request query-aware highlights or full-page content for each result."
-                        },
-                        "crawl_timeout": {
-                          "type": "integer",
-                          "minimum": 1,
-                          "maximum": 60,
-                          "description": "Seconds to wait while crawling pages for extraction."
-                        }
+                    "livecrawl": {
+                      "type": "string",
+                      "enum": ["web", "news", "all"],
+                      "description": "Fetch full page content for the selected sections. Adds latency and per-page charges, including results omitted by maxResults. Content is preserved in result metadata.contents."
+                    },
+                    "livecrawl_formats": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 2,
+                      "uniqueItems": true,
+                      "items": {
+                        "type": "string",
+                        "enum": ["html", "markdown"]
                       },
-                      "description": "Optional extraction controls for the You.com Search API POST endpoint.",
-                      "additionalProperties": false
+                      "description": "Formats for livecrawled content. Defaults to html; requires livecrawl to enable crawling."
+                    },
+                    "crawl_timeout": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 60,
+                      "description": "Seconds to wait for page content when livecrawl is enabled. Defaults to 10."
                     }
                   },
-                  "description": "You.com search options.",
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "include_domains": false
+                      }
+                    },
+                    {
+                      "properties": {
+                        "exclude_domains": false,
+                        "boost_domains": false
+                      }
+                    }
+                  ],
+                  "description": "You.com search options. Results alternate web and news, starting with web, up to maxResults (capped at 100).",
                   "additionalProperties": false
                 }
               }

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -20,6 +20,7 @@ export const PROVIDER_IDS = [
   "serper",
   "tavily",
   "valyu",
+  "youcom",
 ] as const;
 export type ProviderId = (typeof PROVIDER_IDS)[number];
 

--- a/src/providers/contract.ts
+++ b/src/providers/contract.ts
@@ -105,6 +105,7 @@ export interface ProviderConfigMap {
   serper: import("./serper/types.js").Serper;
   tavily: import("./tavily/types.js").Tavily;
   valyu: import("./valyu/types.js").Valyu;
+  youcom: import("./youcom/types.js").Youcom;
 }
 export type ProviderConfig<T extends ProviderId = ProviderId> =
   ProviderConfigMap[T];

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -12,6 +12,7 @@ import { perplexityProvider } from "./perplexity/definition.js";
 import { serperProvider } from "./serper/definition.js";
 import { tavilyProvider } from "./tavily/definition.js";
 import { valyuProvider } from "./valyu/definition.js";
+import { youcomProvider } from "./youcom/definition.js";
 
 export const providers = {
   brave: braveProvider,
@@ -28,4 +29,5 @@ export const providers = {
   serper: serperProvider,
   tavily: tavilyProvider,
   valyu: valyuProvider,
+  youcom: youcomProvider,
 } as const;

--- a/src/providers/youcom/adapter.ts
+++ b/src/providers/youcom/adapter.ts
@@ -1,0 +1,176 @@
+import { httpError, WebfoxError } from "../../errors.js";
+import type { ProviderContext, SearchResponse } from "../contract.js";
+import { trimSnippet } from "../shared.js";
+import type { Youcom } from "./types.js";
+
+const DEFAULT_BASE_URL = "https://ydc-index.io";
+
+export const adapter = {
+  async search(
+    request: import("../contract.js").ProviderRequest<"search">,
+    config: Youcom,
+    context: ProviderContext,
+  ): Promise<SearchResponse> {
+    const apiKey = config.credentials?.api;
+    if (!apiKey) throw new Error("You.com search is missing an API key");
+
+    const options = asRecord(request.options);
+    validateDomainFilters(options);
+
+    const response = await fetch(joinUrl(config.baseUrl), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-API-Key": apiKey,
+      },
+      body: JSON.stringify({
+        query: request.query,
+        count: clamp(request.maxResults, 100),
+        ...pickDefined(options, [
+          "freshness",
+          "country",
+          "language",
+          "safesearch",
+          "knowledge",
+          "offset",
+          "include_domains",
+          "exclude_domains",
+          "boost_domains",
+          "extraction",
+        ]),
+      }),
+      signal: context.signal,
+    });
+
+    if (!response.ok) throw httpError(response, await buildHttpError(response));
+
+    const payload = asRecord(await response.json());
+    const searchMetadata = asRecord(payload.metadata);
+    const results = [
+      ...collectResults(asRecord(payload.results).web, "web", searchMetadata),
+      ...collectResults(asRecord(payload.results).news, "news", searchMetadata),
+    ];
+
+    return {
+      provider: "youcom",
+      results: results.slice(0, clamp(request.maxResults, 100)),
+    };
+  },
+};
+
+function joinUrl(baseUrl?: string): string {
+  return `${(baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "")}/v1/search`;
+}
+
+function validateDomainFilters(options: Record<string, unknown>): void {
+  const includeDomains = arrayOfStrings(options.include_domains);
+  const excludeDomains = arrayOfStrings(options.exclude_domains);
+  const boostDomains = arrayOfStrings(options.boost_domains);
+
+  if (includeDomains.length > 0 && excludeDomains.length > 0) {
+    throw new WebfoxError(
+      "INVALID_INPUT",
+      "You.com search options include_domains and exclude_domains cannot be used together.",
+    );
+  }
+  if (includeDomains.length > 0 && boostDomains.length > 0) {
+    throw new WebfoxError(
+      "INVALID_INPUT",
+      "You.com search options include_domains and boost_domains cannot be used together.",
+    );
+  }
+}
+
+function collectResults(
+  results: unknown,
+  section: "web" | "news",
+  searchMetadata: Record<string, unknown> | undefined,
+): Array<{
+  title: string;
+  url: string;
+  snippet: string;
+  metadata?: Record<string, unknown>;
+}> {
+  return array(results)
+    .map((entry) => asRecord(entry))
+    .filter((entry) => Object.keys(entry).length > 0)
+    .map((entry) => {
+      const url = string(entry.url) ?? "";
+      const title = string(entry.title) ?? string(entry.name) ?? (url || "Untitled");
+      return {
+        title,
+        url,
+        snippet: buildSnippet(entry, section),
+        metadata: buildMetadata(entry, section, searchMetadata),
+      };
+    });
+}
+
+function buildSnippet(
+  entry: Record<string, unknown>,
+  section: "web" | "news",
+): string {
+  const contents = asRecord(entry.contents);
+  const snippets = [...arrayOfStrings(entry.snippets), ...arrayOfStrings(contents.highlights)];
+  if (snippets.length > 0) return trimSnippet(snippets.join("\n\n"), 1200);
+
+  const text =
+    string(entry.description) ??
+    string(contents.markdown) ??
+    string(contents.html) ??
+    (section === "news" ? string(entry.page_age) : undefined) ??
+    "";
+
+  return trimSnippet(text);
+}
+
+function buildMetadata(
+  entry: Record<string, unknown>,
+  section: "web" | "news",
+  searchMetadata: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  const metadata = {
+    section,
+    ...(searchMetadata ? { searchMetadata } : {}),
+    ...entry,
+  };
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}
+
+function pickDefined(
+  source: Record<string, unknown>,
+  keys: string[],
+): Record<string, unknown> {
+  return Object.fromEntries(
+    keys.flatMap((key) =>
+      source[key] === undefined ? [] : ([[key, source[key]]] as const),
+    ),
+  );
+}
+
+function clamp(value: number, max: number): number {
+  return Math.max(1, Math.min(max, Math.trunc(value || 0)));
+}
+
+function array(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function arrayOfStrings(value: unknown): string[] {
+  return array(value).flatMap((entry) => (typeof entry === "string" ? [entry] : []));
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function string(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+async function buildHttpError(response: Response): Promise<string> {
+  const body = (await response.text()).trim();
+  return `You.com search request failed (${response.status}${response.statusText ? ` ${response.statusText}` : ""})${body ? `: ${body}` : "."}`;
+}

--- a/src/providers/youcom/adapter.ts
+++ b/src/providers/youcom/adapter.ts
@@ -1,4 +1,4 @@
-import { httpError, WebfoxError } from "../../errors.js";
+import { httpError } from "../../errors.js";
 import type { ProviderContext, SearchResponse } from "../contract.js";
 import { trimSnippet } from "../shared.js";
 import type { Youcom } from "./types.js";
@@ -15,7 +15,6 @@ export const adapter = {
     if (!apiKey) throw new Error("You.com search is missing an API key");
 
     const options = asRecord(request.options);
-    validateDomainFilters(options);
 
     const response = await fetch(joinUrl(config.baseUrl), {
       method: "POST",
@@ -31,12 +30,13 @@ export const adapter = {
           "country",
           "language",
           "safesearch",
-          "knowledge",
           "offset",
           "include_domains",
           "exclude_domains",
           "boost_domains",
-          "extraction",
+          "livecrawl",
+          "livecrawl_formats",
+          "crawl_timeout",
         ]),
       }),
       signal: context.signal,
@@ -46,10 +46,23 @@ export const adapter = {
 
     const payload = asRecord(await response.json());
     const searchMetadata = asRecord(payload.metadata);
-    const results = [
-      ...collectResults(asRecord(payload.results).web, "web", searchMetadata),
-      ...collectResults(asRecord(payload.results).news, "news", searchMetadata),
-    ];
+    const web = collectResults(
+      asRecord(payload.results).web,
+      "web",
+      searchMetadata,
+    );
+    const news = collectResults(
+      asRecord(payload.results).news,
+      "news",
+      searchMetadata,
+    );
+    // Count applies per section upstream. Interleave before imposing the shared
+    // overall limit so a full web section cannot hide all news results.
+    const results = [];
+    for (let index = 0; index < Math.max(web.length, news.length); index++) {
+      if (web[index]) results.push(web[index]);
+      if (news[index]) results.push(news[index]);
+    }
 
     return {
       provider: "youcom",
@@ -60,25 +73,6 @@ export const adapter = {
 
 function joinUrl(baseUrl?: string): string {
   return `${(baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "")}/v1/search`;
-}
-
-function validateDomainFilters(options: Record<string, unknown>): void {
-  const includeDomains = arrayOfStrings(options.include_domains);
-  const excludeDomains = arrayOfStrings(options.exclude_domains);
-  const boostDomains = arrayOfStrings(options.boost_domains);
-
-  if (includeDomains.length > 0 && excludeDomains.length > 0) {
-    throw new WebfoxError(
-      "INVALID_INPUT",
-      "You.com search options include_domains and exclude_domains cannot be used together.",
-    );
-  }
-  if (includeDomains.length > 0 && boostDomains.length > 0) {
-    throw new WebfoxError(
-      "INVALID_INPUT",
-      "You.com search options include_domains and boost_domains cannot be used together.",
-    );
-  }
 }
 
 function collectResults(
@@ -96,7 +90,8 @@ function collectResults(
     .filter((entry) => Object.keys(entry).length > 0)
     .map((entry) => {
       const url = string(entry.url) ?? "";
-      const title = string(entry.title) ?? string(entry.name) ?? (url || "Untitled");
+      const title =
+        string(entry.title) ?? string(entry.name) ?? (url || "Untitled");
       return {
         title,
         url,
@@ -111,7 +106,7 @@ function buildSnippet(
   section: "web" | "news",
 ): string {
   const contents = asRecord(entry.contents);
-  const snippets = [...arrayOfStrings(entry.snippets), ...arrayOfStrings(contents.highlights)];
+  const snippets = arrayOfStrings(entry.snippets);
   if (snippets.length > 0) return trimSnippet(snippets.join("\n\n"), 1200);
 
   const text =
@@ -157,7 +152,9 @@ function array(value: unknown): unknown[] {
 }
 
 function arrayOfStrings(value: unknown): string[] {
-  return array(value).flatMap((entry) => (typeof entry === "string" ? [entry] : []));
+  return array(value).flatMap((entry) =>
+    typeof entry === "string" ? [entry] : [],
+  );
 }
 
 function asRecord(value: unknown): Record<string, unknown> {

--- a/src/providers/youcom/definition.ts
+++ b/src/providers/youcom/definition.ts
@@ -1,34 +1,17 @@
 import { defineProvider } from "../definition.js";
 
-const extraction = {
-  type: "object",
-  properties: {
-    extraction_mode: {
-      type: "string",
-      enum: ["highlights", "full_page"],
-      description:
-        "Request query-aware highlights or full-page content for each result.",
-    },
-    crawl_timeout: {
-      type: "integer",
-      minimum: 1,
-      maximum: 60,
-      description: "Seconds to wait while crawling pages for extraction.",
-    },
-  },
-  description:
-    "Optional extraction controls for the You.com Search API POST endpoint.",
-};
-
+// Wire names and enums follow the POST Search API, not SDK camelCase names:
+// https://you.com/docs/api-reference/search/v1-search-post.md
 const domains = {
   type: "array",
-  items: { type: "string" },
+  maxItems: 500,
+  items: { type: "string", minLength: 1 },
 };
 
 export const youcomProvider = defineProvider({
   id: "youcom",
   label: "You.com",
-  docsUrl: "https://you.com/docs/api-reference/search/v1-search",
+  docsUrl: "https://you.com/docs/api-reference/search/v1-search-post",
   local: false,
   credentials: [
     {
@@ -48,60 +31,172 @@ export const youcomProvider = defineProvider({
           freshness: {
             type: "string",
             description:
-              "Freshness window such as day, week, month, year, or a YYYY-MM-DDtoYYYY-MM-DD range.",
+              "Freshness window: day, week, month, year, or YYYY-MM-DDtoYYYY-MM-DD. You.com uses the broader timeframe when the query also specifies one.",
           },
           country: {
             type: "string",
+            enum: [
+              "AR",
+              "AU",
+              "AT",
+              "BE",
+              "BR",
+              "CA",
+              "CL",
+              "DK",
+              "FI",
+              "FR",
+              "DE",
+              "HK",
+              "IN",
+              "ID",
+              "IT",
+              "JP",
+              "KR",
+              "MY",
+              "MX",
+              "NL",
+              "NZ",
+              "NO",
+              "CN",
+              "PL",
+              "PT",
+              "PH",
+              "RU",
+              "SA",
+              "ZA",
+              "ES",
+              "SE",
+              "CH",
+              "TW",
+              "TR",
+              "GB",
+              "US",
+            ],
             description:
               "Country code used to localize search results, for example US.",
           },
           language: {
             type: "string",
+            enum: [
+              "AR",
+              "EU",
+              "BN",
+              "BG",
+              "CA",
+              "ZH-HANS",
+              "ZH-HANT",
+              "HR",
+              "CS",
+              "DA",
+              "NL",
+              "EN",
+              "EN-GB",
+              "ET",
+              "FI",
+              "FR",
+              "GL",
+              "DE",
+              "EL",
+              "GU",
+              "HE",
+              "HI",
+              "HU",
+              "IS",
+              "IT",
+              "JA",
+              "KN",
+              "KO",
+              "LV",
+              "LT",
+              "MS",
+              "ML",
+              "MR",
+              "NB",
+              "PL",
+              "PT-BR",
+              "PT-PT",
+              "PA",
+              "RO",
+              "RU",
+              "SR",
+              "SK",
+              "SL",
+              "ES",
+              "SV",
+              "TA",
+              "TE",
+              "TH",
+              "TR",
+              "UK",
+              "VI",
+            ],
             description:
-              "Language for the returned web results, for example en.",
+              "Language of web results. Uses You.com's uppercase codes; defaults to EN.",
           },
           safesearch: {
             type: "string",
             enum: ["moderate", "off", "strict"],
-            description: "Safe-search filtering level.",
-          },
-          knowledge: {
-            type: "boolean",
-            description:
-              "Include knowledge results alongside web and news results.",
+            description: "Safe-search filtering level. Defaults to moderate.",
           },
           offset: {
             type: "integer",
             minimum: 0,
             maximum: 9,
             description:
-              "Pagination offset. Results are returned in count-sized pages.",
+              "Pagination offset in count-sized pages, separately for web and news. Count is maxResults capped at 100.",
           },
           include_domains: {
             ...domains,
             description:
-              "Allowlist of domains to return from You.com search results.",
+              "Restrict results to these domains. Cannot be combined with exclude_domains or boost_domains.",
           },
           exclude_domains: {
             ...domains,
             description:
-              "Blocklist of domains to exclude from You.com search results.",
+              "Exclude these domains. Cannot be combined with include_domains.",
           },
           boost_domains: {
             ...domains,
             description:
-              "Domains to boost in ranking without filtering out other results.",
+              "Boost these domains without excluding others. Can be combined with exclude_domains, but not include_domains.",
           },
-          extraction,
+          livecrawl: {
+            type: "string",
+            enum: ["web", "news", "all"],
+            description:
+              "Fetch full page content for the selected sections. Adds latency and per-page charges, including results omitted by maxResults. Content is preserved in result metadata.contents.",
+          },
+          livecrawl_formats: {
+            type: "array",
+            minItems: 1,
+            maxItems: 2,
+            uniqueItems: true,
+            items: { type: "string", enum: ["html", "markdown"] },
+            description:
+              "Formats for livecrawled content. Defaults to html; requires livecrawl to enable crawling.",
+          },
+          crawl_timeout: {
+            type: "integer",
+            minimum: 1,
+            maximum: 60,
+            description:
+              "Seconds to wait for page content when livecrawl is enabled. Defaults to 10.",
+          },
         },
-        description: "You.com search options.",
+        // Property prohibitions also work for partial configured defaults:
+        // unlike required-based exclusions, they survive partial validation.
+        anyOf: [
+          { properties: { include_domains: false } },
+          { properties: { exclude_domains: false, boost_domains: false } },
+        ],
+        description:
+          "You.com search options. Results alternate web and news, starting with web, up to maxResults (capped at 100).",
       },
       promptGuidelines: [
-        "Use You.com search for fresh web and news results when the task benefits from a structured search API.",
-        "Use include_domains or exclude_domains when the user wants to focus on a known source set.",
-        "Use extraction_mode: highlights when the task needs query-aware passages for RAG or retrieval loops.",
-        "Use extraction_mode: full_page only when the caller needs the underlying page content in the search response.",
-        "Favor You.com when the workflow needs a search provider that can surface both web and news results from one request.",
+        "Use You.com search for web and news results. Results alternate web and news, starting with web, within the overall result limit.",
+        "Use include_domains to restrict sources, or exclude_domains and boost_domains to adjust source selection. Do not combine include_domains with either of the other domain controls.",
+        "Search snippets already contain query-relevant passages. Enable livecrawl only when full page content is needed; it adds latency and per-page charges.",
       ],
       retrySafe: true,
     },

--- a/src/providers/youcom/definition.ts
+++ b/src/providers/youcom/definition.ts
@@ -1,0 +1,110 @@
+import { defineProvider } from "../definition.js";
+
+const extraction = {
+  type: "object",
+  properties: {
+    extraction_mode: {
+      type: "string",
+      enum: ["highlights", "full_page"],
+      description:
+        "Request query-aware highlights or full-page content for each result.",
+    },
+    crawl_timeout: {
+      type: "integer",
+      minimum: 1,
+      maximum: 60,
+      description: "Seconds to wait while crawling pages for extraction.",
+    },
+  },
+  description:
+    "Optional extraction controls for the You.com Search API POST endpoint.",
+};
+
+const domains = {
+  type: "array",
+  items: { type: "string" },
+};
+
+export const youcomProvider = defineProvider({
+  id: "youcom",
+  label: "You.com",
+  docsUrl: "https://you.com/docs/api-reference/search/v1-search",
+  local: false,
+  credentials: [
+    {
+      name: "api",
+      environmentVariable: "YDC_API_KEY",
+      capabilities: ["search"],
+    },
+  ],
+  fields: ["credentials", "baseUrl", "options"],
+  defaults: {},
+  credentialDefaults: {},
+  capabilities: {
+    search: {
+      options: {
+        type: "object",
+        properties: {
+          freshness: {
+            type: "string",
+            description:
+              "Freshness window such as day, week, month, year, or a YYYY-MM-DDtoYYYY-MM-DD range.",
+          },
+          country: {
+            type: "string",
+            description:
+              "Country code used to localize search results, for example US.",
+          },
+          language: {
+            type: "string",
+            description:
+              "Language for the returned web results, for example en.",
+          },
+          safesearch: {
+            type: "string",
+            enum: ["moderate", "off", "strict"],
+            description: "Safe-search filtering level.",
+          },
+          knowledge: {
+            type: "boolean",
+            description:
+              "Include knowledge results alongside web and news results.",
+          },
+          offset: {
+            type: "integer",
+            minimum: 0,
+            maximum: 9,
+            description:
+              "Pagination offset. Results are returned in count-sized pages.",
+          },
+          include_domains: {
+            ...domains,
+            description:
+              "Allowlist of domains to return from You.com search results.",
+          },
+          exclude_domains: {
+            ...domains,
+            description:
+              "Blocklist of domains to exclude from You.com search results.",
+          },
+          boost_domains: {
+            ...domains,
+            description:
+              "Domains to boost in ranking without filtering out other results.",
+          },
+          extraction,
+        },
+        description: "You.com search options.",
+      },
+      promptGuidelines: [
+        "Use You.com search for fresh web and news results when the task benefits from a structured search API.",
+        "Use include_domains or exclude_domains when the user wants to focus on a known source set.",
+        "Use extraction_mode: highlights when the task needs query-aware passages for RAG or retrieval loops.",
+        "Use extraction_mode: full_page only when the caller needs the underlying page content in the search response.",
+        "Favor You.com when the workflow needs a search provider that can surface both web and news results from one request.",
+      ],
+      retrySafe: true,
+    },
+  },
+  load: async () => (await import("./adapter.js")).adapter,
+});

--- a/src/providers/youcom/types.ts
+++ b/src/providers/youcom/types.ts
@@ -1,0 +1,5 @@
+import type { Provider } from "../contract.js";
+
+export interface Youcom extends Provider {
+  baseUrl?: string;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -5,11 +5,12 @@ import { EventEmitter } from "node:events";
 import { mkdtemp, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOptionFlags, runCli } from "../src/cli.js";
 import { customConfig } from "./helpers.js";
 const directories: string[] = [];
 afterEach(async () => {
+  vi.unstubAllGlobals();
   await Promise.all(
     directories
       .splice(0)
@@ -58,6 +59,78 @@ async function cli(
   return { code, stdout, stderr };
 }
 describe("CLI contracts", () => {
+  it("exposes You.com native flags and forwards them through the public client", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "webfox-youcom-"));
+    directories.push(cwd);
+    const config = join(cwd, "config.yaml");
+    await writeFile(
+      config,
+      stringify({
+        providers: {
+          youcom: { credentials: { api: { value: "cli-test-key" } } },
+        },
+      }),
+    );
+    const fetch = vi.fn().mockResolvedValue(
+      Response.json({
+        results: {
+          web: [
+            {
+              title: "Example",
+              url: "https://example.com",
+              snippets: ["A passage"],
+              contents: { markdown: "# Full page" },
+            },
+          ],
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetch);
+    const result = await cli([
+      "search",
+      "example",
+      "--config",
+      config,
+      "--provider",
+      "youcom",
+      "--country",
+      "US",
+      "--language",
+      "EN",
+      "--freshness",
+      "week",
+      "--include-domains",
+      "example.com",
+      "--livecrawl",
+      "web",
+      "--livecrawl-formats",
+      "markdown",
+      "--crawl-timeout",
+      "10",
+      "--format",
+      "json",
+    ]);
+    expect(result.code).toBe(0);
+    expect(JSON.parse(fetch.mock.calls[0][1].body)).toMatchObject({
+      query: "example",
+      country: "US",
+      language: "EN",
+      freshness: "week",
+      include_domains: ["example.com"],
+      livecrawl: "web",
+      livecrawl_formats: ["markdown"],
+      crawl_timeout: 10,
+    });
+    expect(
+      JSON.parse(result.stdout).results[0].value.results[0].metadata.contents,
+    ).toEqual({ markdown: "# Full page" });
+    const help = await cli(["search", "--provider", "youcom", "--help"]);
+    expect(help.code).toBe(0);
+    expect(help.stdout).toContain("--livecrawl-formats");
+    expect(help.stdout).toContain("--boost-domains");
+    expect(help.stdout).not.toContain("--extraction");
+    expect(help.stdout).not.toContain("--knowledge");
+  });
   it.each(["claude", "codex"])(
     "rejects removed provider %s instead of falling back",
     async (provider) => {

--- a/test/provider-option-contracts.test.ts
+++ b/test/provider-option-contracts.test.ts
@@ -127,18 +127,17 @@ const samples: Array<{
     options: {
       freshness: "week",
       country: "US",
-      language: "en",
+      language: "EN",
       safesearch: "moderate",
       include_domains: ["example.com"],
-      extraction: {
-        extraction_mode: "highlights",
-        crawl_timeout: 10,
-      },
+      livecrawl: "web",
+      livecrawl_formats: ["markdown"],
+      crawl_timeout: 10,
     },
   },
 ];
 it.each(samples)(
-  "accepts SDK-backed $provider $capability controls",
+  "accepts provider-native $provider $capability controls",
   ({ provider, capability, options }) => {
     expect(() =>
       validateOptions(providers[provider], capability, options),

--- a/test/provider-option-contracts.test.ts
+++ b/test/provider-option-contracts.test.ts
@@ -121,6 +121,21 @@ const samples: Array<{
       } satisfies DeepResearchTools,
     },
   },
+  {
+    provider: "youcom",
+    capability: "search",
+    options: {
+      freshness: "week",
+      country: "US",
+      language: "en",
+      safesearch: "moderate",
+      include_domains: ["example.com"],
+      extraction: {
+        extraction_mode: "highlights",
+        crawl_timeout: 10,
+      },
+    },
+  },
 ];
 it.each(samples)(
   "accepts SDK-backed $provider $capability controls",

--- a/test/provider-sdk-wire.test.ts
+++ b/test/provider-sdk-wire.test.ts
@@ -41,6 +41,29 @@ function client(provider: ProviderId) {
   });
 }
 
+it("forwards You.com's POST search controls through its HTTP adapter", async () => {
+  response = { results: { web: [], news: [] }, metadata: { query: "q" } };
+  const options = {
+    country: "US",
+    language: "EN",
+    livecrawl: "all",
+    livecrawl_formats: ["markdown"],
+    crawl_timeout: 10,
+    exclude_domains: ["spam.example.com"],
+    boost_domains: ["example.com"],
+  };
+  const result = await client("youcom").search({
+    provider: "youcom",
+    queries: ["q"],
+    maxResults: 3,
+    options,
+  });
+  expect(result.status).toBe("ok");
+  expect(requests).toEqual([
+    { path: "/v1/search", body: { query: "q", count: 3, ...options } },
+  ]);
+});
+
 it("forwards Firecrawl's distinct search and scrape location shapes through its SDK", async () => {
   response = { success: true, data: { web: [] } };
   const options = {

--- a/test/youcom-provider.test.ts
+++ b/test/youcom-provider.test.ts
@@ -1,157 +1,318 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createWebfox, validateConfiguredOptions } from "../src/index.js";
+import { validateOptions } from "../src/configuration/planning.js";
+import { configurationSchema } from "../src/configuration/schema.js";
+import { Check } from "typebox/value";
+import { adapter } from "../src/providers/youcom/adapter.js";
 import { youcomProvider } from "../src/providers/youcom/definition.js";
-import { providerHarness } from "./provider-harness.js";
 
-const originalFetch = globalThis.fetch;
+// Wire fixture follows https://you.com/docs/api-reference/search/v1-search-post.md.
+const web = {
+  url: "https://example.com/web",
+  title: "Web result",
+  description: "Web description",
+  snippets: ["First passage", "Second passage"],
+  favicon_url: "https://example.com/favicon.ico",
+  contents: { markdown: "# Full page\n\nContent", html: "<h1>Full page</h1>" },
+};
+const news = {
+  url: "https://example.com/news",
+  title: "News result",
+  description: "News description",
+  page_age: "2025-11-25T12:31:29",
+  thumbnail_url: "https://example.com/news.png",
+};
+const metadata = { query: "example", search_uuid: "uuid-123", latency: 0.23 };
+const payload = { results: { web: [web], news: [news] }, metadata };
 
-afterEach(() => {
-  delete process.env.YDC_API_KEY;
-  globalThis.fetch = originalFetch;
-  vi.restoreAllMocks();
-});
+function mockResponse(body: unknown = payload, status = 200) {
+  return vi
+    .fn()
+    .mockImplementation(async () => Response.json(body, { status }));
+}
+function client(options: Record<string, unknown> = {}) {
+  return createWebfox({
+    config: {
+      defaults: { search: { provider: "youcom" } },
+      execution: { retries: 0 },
+      providers: { youcom: { options: { search: options } } },
+    },
+    env: { YDC_API_KEY: "test-key" },
+  });
+}
+afterEach(() => vi.unstubAllGlobals());
 
-describe("providerHarness(youcomProvider)", () => {
-  it("maps web and news results and forwards search controls", async () => {
-    process.env.YDC_API_KEY = "test-key";
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          results: {
-            web: [
-              {
-                url: "https://example.com/web",
-                title: "Web Result",
-                description: "Web description",
-                snippets: ["Web snippet", "Second snippet"],
-                favicon_url: "https://example.com/favicon.ico",
-              },
-            ],
-            news: [
-              {
-                url: "https://example.com/news",
-                title: "News Result",
-                description: "News description",
-                page_age: "2026-09-07T16:00:00",
-                thumbnail_url: "https://example.com/news.png",
-              },
-            ],
-          },
-          metadata: {
-            query: "example query",
-            search_uuid: "uuid-123",
-            latency: 0.23,
-          },
-        }),
-        { status: 200 },
-      ),
-    );
-    globalThis.fetch = fetchMock as typeof fetch;
-
-    const response = await providerHarness(youcomProvider).search(
-      "example query",
-      7,
-      { credentials: { api: "test-key" } },
-      { cwd: process.cwd() },
-      {
-        freshness: "week",
-        country: "US",
-        language: "en",
-        safesearch: "strict",
-        knowledge: true,
-        offset: 2,
-        include_domains: ["example.com"],
-        extraction: {
-          extraction_mode: "highlights",
-          crawl_timeout: 15,
-        },
-      },
-    );
-
-    expect(fetchMock).toHaveBeenCalledWith("https://ydc-index.io/v1/search", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "X-API-Key": "test-key",
-      },
-      body: JSON.stringify({
-        query: "example query",
-        count: 7,
-        freshness: "week",
-        country: "US",
-        language: "en",
-        safesearch: "strict",
-        knowledge: true,
-        offset: 2,
-        include_domains: ["example.com"],
-        extraction: {
-          extraction_mode: "highlights",
-          crawl_timeout: 15,
-        },
-      }),
-      signal: undefined,
-    });
-    expect(response).toEqual({
-      provider: "youcom",
-      results: [
+describe("You.com search", () => {
+  it("exposes credentials, capabilities, and native option schemas without initializing transport", () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    expect(client().getProvider("youcom")).toMatchObject({
+      capabilities: ["search"],
+      configured: ["search"],
+      selectedDefaults: ["search"],
+      credentials: [
         {
-          title: "Web Result",
-          url: "https://example.com/web",
-          snippet: "Web snippet Second snippet",
-          metadata: {
-            section: "web",
-            searchMetadata: {
-              query: "example query",
-              search_uuid: "uuid-123",
-              latency: 0.23,
-            },
-            url: "https://example.com/web",
-            title: "Web Result",
-            description: "Web description",
-            snippets: ["Web snippet", "Second snippet"],
-            favicon_url: "https://example.com/favicon.ico",
-          },
-        },
-        {
-          title: "News Result",
-          url: "https://example.com/news",
-          snippet: "News description",
-          metadata: {
-            section: "news",
-            searchMetadata: {
-              query: "example query",
-              search_uuid: "uuid-123",
-              latency: 0.23,
-            },
-            url: "https://example.com/news",
-            title: "News Result",
-            description: "News description",
-            page_age: "2026-09-07T16:00:00",
-            thumbnail_url: "https://example.com/news.png",
-          },
+          name: "api",
+          environmentVariable: "YDC_API_KEY",
+          capabilities: ["search"],
         },
       ],
     });
+    const schema = client().inspectCapability("search").optionSchema!;
+    expect(schema.properties).toHaveProperty("livecrawl");
+    expect(schema.properties).not.toHaveProperty("extraction");
+    expect(schema.additionalProperties).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("rejects conflicting domain filters before making a request", async () => {
-    const fetchMock = vi.fn();
-    globalThis.fetch = fetchMock as typeof fetch;
+  it("maps the POST contract, configured defaults, request overrides, and extracted metadata", async () => {
+    const fetch = mockResponse();
+    vi.stubGlobal("fetch", fetch);
+    const result = await client({
+      country: "US",
+      language: "EN",
+      freshness: "month",
+    }).search({
+      queries: ["example"],
+      maxResults: 7,
+      options: {
+        freshness: "week",
+        safesearch: "strict",
+        offset: 2,
+        include_domains: ["example.com"],
+        livecrawl: "all",
+        livecrawl_formats: ["markdown", "html"],
+        crawl_timeout: 15,
+      },
+    });
+    expect(fetch).toHaveBeenCalledOnce();
+    const [url, init] = fetch.mock.calls[0];
+    expect(url).toBe("https://ydc-index.io/v1/search");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      "content-type": "application/json",
+      "X-API-Key": "test-key",
+    });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(JSON.parse(init.body)).toEqual({
+      query: "example",
+      count: 7,
+      country: "US",
+      language: "EN",
+      freshness: "week",
+      safesearch: "strict",
+      offset: 2,
+      include_domains: ["example.com"],
+      livecrawl: "all",
+      livecrawl_formats: ["markdown", "html"],
+      crawl_timeout: 15,
+    });
+    expect(result.status).toBe("ok");
+    expect(result.results[0]).toMatchObject({
+      ok: true,
+      value: {
+        results: [
+          {
+            title: web.title,
+            url: web.url,
+            snippet: "First passage Second passage",
+            metadata: { ...web, section: "web", searchMetadata: metadata },
+          },
+          {
+            title: news.title,
+            url: news.url,
+            snippet: news.description,
+            metadata: { ...news, section: "news", searchMetadata: metadata },
+          },
+        ],
+      },
+    });
+  });
 
-    await expect(
-      providerHarness(youcomProvider).search(
-        "example query",
-        5,
+  it.each([
+    [5, 5, 5, ["web", "news", "web", "news", "web"]],
+    [5, 1, 5, ["web", "news", "web", "web", "web"]],
+    [0, 3, 5, ["news", "news", "news"]],
+    [3, 0, 5, ["web", "web", "web"]],
+    [0, 0, 5, []],
+    [3, 3, 1, ["web"]],
+  ])(
+    "interleaves %i web and %i news results within limit %i",
+    async (webCount, newsCount, maxResults, sections) => {
+      vi.stubGlobal(
+        "fetch",
+        mockResponse({
+          results: {
+            web: Array.from({ length: webCount }, (_, i) => ({
+              ...web,
+              title: `Web ${i}`,
+            })),
+            news: Array.from({ length: newsCount }, (_, i) => ({
+              ...news,
+              title: `News ${i}`,
+            })),
+          },
+        }),
+      );
+      const result = await adapter.search(
+        { capability: "search", query: "example", maxResults },
         { credentials: { api: "test-key" } },
         { cwd: process.cwd() },
-        {
-          include_domains: ["example.com"],
-          exclude_domains: ["news.example.com"],
-        },
-      ),
-    ).rejects.toThrow(
-      "You.com search options include_domains and exclude_domains cannot be used together.",
-    );
+      );
+      expect(result.results.map((entry) => entry.metadata?.section)).toEqual(
+        sections,
+      );
+      expect(
+        result.results
+          .filter((entry) => entry.metadata?.section === "web")
+          .map((entry) => entry.title),
+      ).toEqual(
+        Array.from(
+          { length: sections.filter((s) => s === "web").length },
+          (_, i) => `Web ${i}`,
+        ),
+      );
+    },
+  );
 
-    expect(fetchMock).not.toHaveBeenCalled();
+  it("caps the per-section count and final result count at 100", async () => {
+    const fetch = mockResponse({
+      results: { web: Array(100).fill(web), news: Array(100).fill(news) },
+    });
+    vi.stubGlobal("fetch", fetch);
+    const result = await adapter.search(
+      { capability: "search", query: "example", maxResults: 150 },
+      { credentials: { api: "test-key" } },
+      { cwd: process.cwd() },
+    );
+    expect(JSON.parse(fetch.mock.calls[0][1].body).count).toBe(100);
+    expect(result.results).toHaveLength(100);
+    expect(
+      result.results.filter((entry) => entry.metadata?.section === "news"),
+    ).toHaveLength(50);
+  });
+
+  it("supports a custom endpoint and propagates cancellation", async () => {
+    const controller = new AbortController();
+    const fetch = vi.fn().mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener(
+            "abort",
+            () => reject(init.signal.reason),
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetch);
+    const pending = adapter.search(
+      { capability: "search", query: "example", maxResults: 5 },
+      {
+        baseUrl: "https://proxy.example.com///",
+        credentials: { api: "test-key" },
+      },
+      { cwd: process.cwd(), signal: controller.signal },
+    );
+    expect(fetch.mock.calls[0][0]).toBe("https://proxy.example.com/v1/search");
+    expect(fetch.mock.calls[0][1].signal).toBe(controller.signal);
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it.each([401, 422, 429, 503])(
+    "classifies and redacts HTTP %i failures",
+    async (status) => {
+      vi.stubGlobal(
+        "fetch",
+        mockResponse({ detail: "request failed for test-key" }, status),
+      );
+      const result = await client().search({ queries: ["example"] });
+      expect(result.status).toBe("partial");
+      expect(result.results[0]).toMatchObject({
+        ok: false,
+        error: {
+          code: "PROVIDER_FAILURE",
+          retryable: status === 429 || status >= 500,
+        },
+      });
+      expect(JSON.stringify(result)).not.toContain("test-key");
+      expect(JSON.stringify(result)).toContain(String(status));
+    },
+  );
+
+  it("rejects missing credentials without making requests", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    await expect(
+      createWebfox({ config: {}, env: {} }).search({
+        provider: "youcom",
+        queries: ["example"],
+      }),
+    ).rejects.toMatchObject({ code: "PROVIDER_UNAVAILABLE" });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { include_domains: ["example.com"], exclude_domains: ["news.example.com"] },
+    { include_domains: ["example.com"], boost_domains: ["news.example.com"] },
+    { include_domains: [], exclude_domains: [] },
+    { include_domains: Array(501).fill("example.com") },
+    { include_domains: [""] },
+    { language: "en" },
+    { country: "ZZ" },
+    { offset: 10 },
+    { livecrawl: "invalid" },
+    { livecrawl_formats: ["text"] },
+    { livecrawl_formats: [] },
+    { crawl_timeout: 0 },
+    { crawl_timeout: 61 },
+    { knowledge: true },
+    { extraction: { extraction_mode: "highlights" } },
+  ])(
+    "rejects invalid native options across schemas and execution: %j",
+    async (options) => {
+      const fetch = vi.fn();
+      vi.stubGlobal("fetch", fetch);
+      expect(() =>
+        validateOptions(youcomProvider, "search", options),
+      ).toThrow();
+      const config = {
+        providers: { youcom: { options: { search: options } } },
+      };
+      expect(() => validateConfiguredOptions(config)).toThrow();
+      expect(Check(configurationSchema, config)).toBe(false);
+      await expect(
+        client().search({ queries: ["example"], options }),
+      ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+      expect(fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects domain conflicts after merging defaults and overrides", async () => {
+    await expect(
+      client({ include_domains: ["example.com"] }).search({
+        queries: ["example"],
+        options: { boost_domains: ["news.example.com"] },
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+  });
+
+  it("accepts and forwards exclusion plus boosting and 500-domain allowlists", async () => {
+    const fetch = mockResponse();
+    vi.stubGlobal("fetch", fetch);
+    for (const options of [
+      { exclude_domains: ["spam.example.com"], boost_domains: ["example.com"] },
+      { include_domains: Array(500).fill("example.com") },
+    ]) {
+      const config = {
+        providers: { youcom: { options: { search: options } } },
+      };
+      expect(() => validateConfiguredOptions(config)).not.toThrow();
+      expect(Check(configurationSchema, config)).toBe(true);
+      expect(
+        (await client().search({ queries: ["example"], options })).status,
+      ).toBe("ok");
+      expect(JSON.parse(fetch.mock.lastCall![1].body)).toMatchObject(options);
+    }
   });
 });

--- a/test/youcom-provider.test.ts
+++ b/test/youcom-provider.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { youcomProvider } from "../src/providers/youcom/definition.js";
+import { providerHarness } from "./provider-harness.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  delete process.env.YDC_API_KEY;
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("providerHarness(youcomProvider)", () => {
+  it("maps web and news results and forwards search controls", async () => {
+    process.env.YDC_API_KEY = "test-key";
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          results: {
+            web: [
+              {
+                url: "https://example.com/web",
+                title: "Web Result",
+                description: "Web description",
+                snippets: ["Web snippet", "Second snippet"],
+                favicon_url: "https://example.com/favicon.ico",
+              },
+            ],
+            news: [
+              {
+                url: "https://example.com/news",
+                title: "News Result",
+                description: "News description",
+                page_age: "2026-09-07T16:00:00",
+                thumbnail_url: "https://example.com/news.png",
+              },
+            ],
+          },
+          metadata: {
+            query: "example query",
+            search_uuid: "uuid-123",
+            latency: 0.23,
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const response = await providerHarness(youcomProvider).search(
+      "example query",
+      7,
+      { credentials: { api: "test-key" } },
+      { cwd: process.cwd() },
+      {
+        freshness: "week",
+        country: "US",
+        language: "en",
+        safesearch: "strict",
+        knowledge: true,
+        offset: 2,
+        include_domains: ["example.com"],
+        extraction: {
+          extraction_mode: "highlights",
+          crawl_timeout: 15,
+        },
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith("https://ydc-index.io/v1/search", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-API-Key": "test-key",
+      },
+      body: JSON.stringify({
+        query: "example query",
+        count: 7,
+        freshness: "week",
+        country: "US",
+        language: "en",
+        safesearch: "strict",
+        knowledge: true,
+        offset: 2,
+        include_domains: ["example.com"],
+        extraction: {
+          extraction_mode: "highlights",
+          crawl_timeout: 15,
+        },
+      }),
+      signal: undefined,
+    });
+    expect(response).toEqual({
+      provider: "youcom",
+      results: [
+        {
+          title: "Web Result",
+          url: "https://example.com/web",
+          snippet: "Web snippet Second snippet",
+          metadata: {
+            section: "web",
+            searchMetadata: {
+              query: "example query",
+              search_uuid: "uuid-123",
+              latency: 0.23,
+            },
+            url: "https://example.com/web",
+            title: "Web Result",
+            description: "Web description",
+            snippets: ["Web snippet", "Second snippet"],
+            favicon_url: "https://example.com/favicon.ico",
+          },
+        },
+        {
+          title: "News Result",
+          url: "https://example.com/news",
+          snippet: "News description",
+          metadata: {
+            section: "news",
+            searchMetadata: {
+              query: "example query",
+              search_uuid: "uuid-123",
+              latency: 0.23,
+            },
+            url: "https://example.com/news",
+            title: "News Result",
+            description: "News description",
+            page_age: "2026-09-07T16:00:00",
+            thumbnail_url: "https://example.com/news.png",
+          },
+        },
+      ],
+    });
+  });
+
+  it("rejects conflicting domain filters before making a request", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      providerHarness(youcomProvider).search(
+        "example query",
+        5,
+        { credentials: { api: "test-key" } },
+        { cwd: process.cwd() },
+        {
+          include_domains: ["example.com"],
+          exclude_domains: ["news.example.com"],
+        },
+      ),
+    ).rejects.toThrow(
+      "You.com search options include_domains and exclude_domains cannot be used together.",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 🔍 Problem

- Add You.com as an optional search backend without changing existing defaults.
- Preserve both web and news results through webfox's shared search interface.

## 🛠️ Solution

- Register a lazy, search-only HTTP provider using `YDC_API_KEY` and the documented JSON POST API.
- Expose native freshness, location/language, pagination, domain filtering/boosting, and live-crawl controls through the library, generated CLI flags, configuration schema, and existing Pi tool.
- Interleave web and news results within the overall limit; retain extracted content in result metadata.
- Validate domain conflicts and supported values before requests, document extraction costs and configuration, and pass the environment secret into live-provider CI.

```sh
web search "Node.js release notes" --provider youcom --freshness week
```

## 💬 Review

- Keeps the existing raw-HTTP provider pattern used by Brave and Serper; option names follow the POST wire contract rather than SDK camelCase names.
- Search-only scope. Live crawling is opt-in and can incur per-page charges, including pages omitted by the final result limit.
- Local validation passed: 346 tests, type checking, build, formatting, changelog validation, and packed-package smoke tests. Four live end-to-end checks also passed using a local configuration credential: basic search, CLI locale/domain filtering, mixed web/news results, and Markdown live crawling.

<sub>
🎫 References https://github.com/youdotcom-oss/integration-tracking/issues/269
</sub>

