### PR TITLE
fix(pi): preserve token option schemas during inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ or, on Windows, `APPDATA`. Override it with `WEBFOX_CONFIG` or `--config <path>`
 For example:
 
 ```yaml
-$schema: https://unpkg.com/webfox@4.0.1/dist/config.schema.json
+$schema: https://unpkg.com/webfox@latest/dist/config.schema.json
 defaults:
   search:
     provider: brave

--- a/changelog/unreleased/preserve-provider-option-schemas-during-inspection.md
+++ b/changelog/unreleased/preserve-provider-option-schemas-during-inspection.md
@@ -1,0 +1,9 @@
+---
+title: Preserve provider option schemas during inspection
+type: bugfix
+authors:
+  - andrew-kurin
+created: 2026-09-08T02:37:30.715356Z
+---
+
+Provider option schemas now remain separate from credential redaction. Previously, fields such as Brave maximum_number_of_tokens were replaced with [redacted], which made Pi tool schemas invalid and caused Codex requests to fail. Configured default values still pass through credential redaction.

--- a/changelog/unreleased/stable-configuration-schema-urls.md
+++ b/changelog/unreleased/stable-configuration-schema-urls.md
@@ -1,0 +1,17 @@
+---
+title: Stable configuration schema URLs
+type: change
+authors:
+  - mavam
+prs:
+  - 41
+created: 2026-09-08T04:53:09.601303Z
+---
+
+Configuration schema URLs now follow the latest published release, so examples no longer need URL updates after every release:
+
+```yaml
+$schema: https://unpkg.com/webfox@latest/dist/config.schema.json
+```
+
+Editor validation follows the latest schema even when an older Webfox version is installed. Replace `latest` with an exact version if you need validation pinned to that release.

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,4 +1,4 @@
-$schema: https://unpkg.com/webfox@4.0.1/dist/config.schema.json
+$schema: https://unpkg.com/webfox@latest/dist/config.schema.json
 defaults:
   search:
     provider: brave

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -9,7 +9,7 @@ const root = resolve(import.meta.dirname, "..");
 const sourcePackageJson = JSON.parse(
   await readFile(join(root, "package.json"), "utf8"),
 );
-const expectedSchemaUrl = `https://unpkg.com/${sourcePackageJson.name}@${sourcePackageJson.version}/dist/config.schema.json`;
+const expectedSchemaUrl = `https://unpkg.com/${sourcePackageJson.name}@latest/dist/config.schema.json`;
 const directory = await mkdtemp(join(tmpdir(), "webfox-package-smoke-"));
 let archive;
 
@@ -60,7 +60,7 @@ try {
       [
         'const library = await import("webfox");',
         'if (typeof library.createWebfox !== "function") throw new Error("missing createWebfox");',
-        `if (library.CONFIG_SCHEMA_URL !== ${JSON.stringify(expectedSchemaUrl)}) throw new Error("library schema version does not match package metadata");`,
+        `if (library.CONFIG_SCHEMA_URL !== ${JSON.stringify(expectedSchemaUrl)}) throw new Error("library schema URL does not target latest");`,
       ].join("\n"),
     ],
     { cwd: directory, stdio: "inherit" },
@@ -90,7 +90,7 @@ try {
     ),
   );
   if (schema.$id !== expectedSchemaUrl)
-    throw new Error("packed schema version does not match package metadata");
+    throw new Error("packed schema URL does not target latest");
   for (const reference of [
     "reference.md",
     "cli-experience.md",

--- a/src/application.ts
+++ b/src/application.ts
@@ -174,28 +174,31 @@ export function createWebfox(options: CreateWebfoxOptions = {}): WebfoxClient {
           },
         };
       const definition = selectProvider(config, capability, selected);
-      return outward.value({
+      const defaults = outward.value({
+        options: effectiveOptions(
+          config,
+          definition,
+          capability,
+          {},
+          "defaults",
+        ),
+        ...(capability === "search"
+          ? { maxResults: config.defaults?.search?.maxResults ?? 5 }
+          : {}),
+      });
+      return {
         capability,
         provider: selected,
         configured: configured(definition, capability),
+        // Static provider schemas contain no credentials. Redacting property
+        // names such as maximum_number_of_tokens would invalidate the schema.
         optionSchema: optionSchema(
           definition,
           capability,
           "defaults",
         ) as unknown as Record<string, unknown> | undefined,
-        defaults: {
-          options: effectiveOptions(
-            config,
-            definition,
-            capability,
-            {},
-            "defaults",
-          ),
-          ...(capability === "search"
-            ? { maxResults: config.defaults?.search?.maxResults ?? 5 }
-            : {}),
-        },
-      });
+        defaults,
+      };
     },
   };
 }

--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://unpkg.com/webfox@4.0.1/dist/config.schema.json",
+  "$id": "https://unpkg.com/webfox@latest/dist/config.schema.json",
   "title": "webfox configuration",
   "type": "object",
   "additionalProperties": false,

--- a/src/package-metadata.ts
+++ b/src/package-metadata.ts
@@ -2,4 +2,4 @@ import packageJson from "../package.json" with { type: "json" };
 
 export const PACKAGE_NAME = packageJson.name;
 export const PACKAGE_VERSION = packageJson.version;
-export const CONFIG_SCHEMA_URL = `https://unpkg.com/${PACKAGE_NAME}@${PACKAGE_VERSION}/dist/config.schema.json`;
+export const CONFIG_SCHEMA_URL = `https://unpkg.com/${PACKAGE_NAME}@latest/dist/config.schema.json`;

--- a/test/package-metadata.test.ts
+++ b/test/package-metadata.test.ts
@@ -26,11 +26,11 @@ describe("package metadata", () => {
       expect(packageJson.bundledDependencies ?? []).not.toContain(peer);
     }
   });
-  it("keeps runtime and static schema URLs aligned with package.json", async () => {
+  it("keeps schema URLs on latest independently of the package version", async () => {
     const packageJson = JSON.parse(
       await readFile(resolve("package.json"), "utf8"),
     );
-    const expectedSchemaUrl = `https://unpkg.com/${packageJson.name}@${packageJson.version}/dist/config.schema.json`;
+    const expectedSchemaUrl = `https://unpkg.com/${packageJson.name}@latest/dist/config.schema.json`;
 
     expect(packageJson.name).toBe("webfox");
     expect(packageJson.bin).toEqual({ web: "./dist/cli.js" });

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -30,3 +30,36 @@ it("inspects supported providers and exact schemas without loading their SDKs", 
   ).toHaveProperty("searchContextSize");
   expect(client.inspectCapability("answer").provider).toBeUndefined();
 });
+it("still redacts credentials from inspected default values", () => {
+  const secret = "inspection-test-secret";
+  const client = createWebfox({
+    config: {
+      providers: {
+        openai: { options: { answer: { model: secret } } },
+      },
+    },
+    env: { OPENAI_API_KEY: secret },
+  });
+  const inspection = client.inspectCapability("answer", "openai");
+  expect(inspection.defaults.options.model).toBe("[redacted]");
+  expect(JSON.stringify(inspection)).not.toContain(secret);
+});
+it("keeps token-budget option schemas intact during inspection", () => {
+  const client = createWebfox({
+    config: { defaults: { search: { provider: "brave" } } },
+    env: { BRAVE_SEARCH_API_KEY: "brave-search-secret" },
+  });
+  expect(client.inspectCapability("search").optionSchema).toMatchObject({
+    properties: {
+      llmContext: {
+        properties: {
+          maximum_number_of_tokens: { type: "integer", minimum: 1 },
+          maximum_number_of_tokens_per_url: {
+            type: "integer",
+            minimum: 1,
+          },
+        },
+      },
+    },
+  });
+});


### PR DESCRIPTION
## Summary
- Keep static provider option schemas outside credential redaction during capability inspection. Continue to redact configured default values.
- Add regression tests for Brave token-budget schemas and credential redaction in inspected defaults.
- Add a changelog entry.

## Problem
With Brave selected for search, `inspectCapability("search")` passes its schema through `OutwardBoundary.value()`. The sensitive-key matcher replaces `maximum_number_of_tokens` and `maximum_number_of_tokens_per_url` schema objects with the string `[redacted]`.

Pi then registers an invalid `web_search` schema. Codex rejects the entire model request:

```text
Invalid schema for function 'web_search': '[redacted]' is not of type 'object', 'boolean'.
```

These are static schema definitions, not credential values. The regression test reproduced the invalid fields before the fix and passes after it.

## Testing
- `npm test -- test/providers.test.ts test/client.test.ts test/pi.test.ts`: 24 tests passed.
- `npm run check`: passed.
- `npm run format:check`: passed.
- `npm run build`: passed.
- `uvx tenzir-ship validate`: passed.
- Live Brave search and Pi/Codex tool invocation passed after reloading the rebuilt extension.
- Full suite during initial validation: 346 passed, 1 failed. The existing package metadata test fails because `example-config.yaml` references version 4.0.1 while `package.json` is 4.1.0; README has the same stale reference. This PR does not change those unrelated files.

Only the implementation, regression tests, and changelog are included. Local generated schema and lockfile changes are excluded.
