### PR TITLE
Keep Pi usable with invalid Webfox configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,9 @@ configuration, progress, and errors.
   `web config default <capability> <provider>`.
 - **Missing credentials:** Run `web providers <id>` to check the required key
   names, or see the [provider guide](./docs/provider.md).
+- **Invalid configuration in pi:** Pi continues to start, but Webfox registers
+  no tools and reports the error (on stderr in print and JSON modes). Fix the
+  configuration, then restart Pi or run `/reload` to load the extension again.
 - **No pi tools:** Select default providers in the shared configuration and
   restart pi. Installing the extension or setting keys alone isn't enough.
 

--- a/changelog/unreleased/non-blocking-pi-startup-with-invalid-configuration.md
+++ b/changelog/unreleased/non-blocking-pi-startup-with-invalid-configuration.md
@@ -3,7 +3,9 @@ title: Non-blocking Pi startup with invalid configuration
 type: bugfix
 authors:
   - mavam
-created: 2026-09-08T04:48:30.942979Z
+prs:
+  - 42
+created: 2026-09-08T04:50:33.84218Z
 ---
 
 Invalid Webfox configuration no longer interrupts Pi startup. The extension reports the configuration error and registers no web tools, leaving Pi available to use. In print and JSON modes, the diagnostic goes to stderr. After fixing the configuration, restart Pi or run `/reload` to load the extension again.

--- a/changelog/unreleased/non-blocking-pi-startup-with-invalid-configuration.md
+++ b/changelog/unreleased/non-blocking-pi-startup-with-invalid-configuration.md
@@ -1,0 +1,9 @@
+---
+title: Non-blocking Pi startup with invalid configuration
+type: bugfix
+authors:
+  - mavam
+created: 2026-09-08T04:48:30.942979Z
+---
+
+Invalid Webfox configuration no longer interrupts Pi startup. The extension reports the configuration error and registers no web tools, leaving Pi available to use. In print and JSON modes, the diagnostic goes to stderr. After fixing the configuration, restart Pi or run `/reload` to load the extension again.

--- a/src/configuration/file.ts
+++ b/src/configuration/file.ts
@@ -64,6 +64,12 @@ function readFailure(
   throw new WebfoxError(
     "INVALID_CONFIG",
     `Could not read configuration: ${path}. Check the path and file permissions.`,
+    {
+      configuration: {
+        source: path,
+        issues: ["Could not read file. Check the path and permissions."],
+      },
+    },
   );
 }
 // Keep the YAML document for narrow, comment-preserving updates.
@@ -102,6 +108,14 @@ export function parseConfigDocument(text: string, source = "config.yaml") {
     throw new WebfoxError(
       "INVALID_CONFIG",
       `Invalid YAML in ${source}. Use one YAML 1.2 document with unique keys, with string keys and finite numbers, without aliases or explicit tags.`,
+      {
+        configuration: {
+          source,
+          issues: [
+            "Invalid YAML. Use YAML 1.2 without duplicate keys, aliases, or explicit tags.",
+          ],
+        },
+      },
     );
   }
 }
@@ -121,17 +135,47 @@ export function validateConfig(
 ): WebfoxConfig {
   const schema = configurationSchema as unknown as TSchema;
   if (!Check(schema, value)) {
-    const detail = Errors(schema, value)
+    const errors = Errors(schema, value);
+    const detail = errors
       .slice(0, 3)
       .map((error) => `${error.instancePath || "/"}: ${error.message}`)
       .join("; ");
     throw new WebfoxError(
       "INVALID_CONFIG",
       `Invalid ${source}: ${detail}. Provider options belong under providers.<id>.options.<capability>.`,
+      { configuration: { source, issues: configurationIssues(errors) } },
     );
   }
   return structuredClone(value) as WebfoxConfig;
 }
+function configurationIssues(errors: ReturnType<typeof Errors>): string[] {
+  const issues = new Map<string, string>();
+  for (const error of errors) {
+    // TypeBox emits both the rejected key and a duplicate parent-object error.
+    if (error.keyword === "additionalProperties") continue;
+    const path = error.instancePath || "/";
+    if (issues.has(path)) continue;
+    const unknownKey =
+      error.keyword === "boolean" &&
+      error.schemaPath.endsWith("/additionalProperties");
+    const key = path
+      .slice(1)
+      .split("/")
+      .map((part) => part.replaceAll("~1", "/").replaceAll("~0", "~"))
+      .join(".");
+    const message = unknownKey
+      ? `Unknown key: ${key}`
+      : error.keyword === "enum" || error.keyword === "const"
+        ? `${path}: unsupported value`
+        : `${path}: ${error.message}`;
+    issues.set(path, message);
+    if (issues.size === 3) break;
+  }
+  return issues.size
+    ? [...issues.values()]
+    : ["Invalid configuration structure."];
+}
+
 export function redactConfig(config: WebfoxConfig): unknown {
   const visit = (entry: unknown): unknown => {
     if (Array.isArray(entry)) return entry.map(visit);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,7 +5,11 @@ export class WebfoxError extends Error {
   constructor(
     public readonly code: WebfoxErrorCode,
     message: string,
-    public readonly options: { cause?: unknown; retryable?: boolean } = {},
+    public readonly options: {
+      cause?: unknown;
+      retryable?: boolean;
+      configuration?: { source: string; issues: string[] };
+    } = {},
   ) {
     super(
       message,

--- a/src/pi-diagnostics.ts
+++ b/src/pi-diagnostics.ts
@@ -1,0 +1,21 @@
+import { homedir } from "node:os";
+import { sep } from "node:path";
+import { resolveConfigPath } from "./configuration/file.js";
+import type { WebfoxError } from "./errors.js";
+
+export function configurationDiagnostic(error: WebfoxError): string {
+  const diagnostic = error.options.configuration;
+  const source = diagnostic?.source ?? resolveConfigPath();
+  const home = homedir() + sep;
+  const path = source.startsWith(home)
+    ? `~/${source.slice(home.length)}`
+    : source;
+  const issues = diagnostic?.issues ?? [error.message];
+  return [
+    "Webfox disabled — invalid configuration",
+    `  ${path}`,
+    ...issues.map((issue) => `  ${issue}`),
+    "",
+    "Fix the configuration, then /reload.",
+  ].join("\n");
+}

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -18,6 +18,7 @@ import {
 import { renderTextDocument } from "./render.js";
 import { prepareToolArguments } from "./pi-validation.js";
 import { WebfoxError } from "./errors.js";
+import { configurationDiagnostic } from "./pi-diagnostics.js";
 
 export default function webExtension(pi: ExtensionAPI): void {
   const clients = new Map<string, WebClient>();
@@ -44,7 +45,7 @@ export default function webExtension(pi: ExtensionAPI): void {
       )
     )
       throw error;
-    const message = `✘︎ Web extension disabled: ${error.message}\nFix the configuration, then restart pi or run /reload.`;
+    const message = configurationDiagnostic(error);
     pi.on("session_start", (_event, context) => {
       if (context.hasUI) context.ui.notify(message, "error");
       else console.error(message);

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -17,6 +17,7 @@ import {
 } from "./index.js";
 import { renderTextDocument } from "./render.js";
 import { prepareToolArguments } from "./pi-validation.js";
+import { WebfoxError } from "./errors.js";
 
 export default function webExtension(pi: ExtensionAPI): void {
   const clients = new Map<string, WebClient>();
@@ -28,10 +29,28 @@ export default function webExtension(pi: ExtensionAPI): void {
     }
     return client;
   };
-  const initial = clientFor(process.cwd());
-  const selected = CAPABILITIES.filter(
-    (capability) => initial.inspectCapability(capability).provider,
-  );
+  let selected: ReturnType<WebClient["inspectCapability"]>[];
+  try {
+    const initial = clientFor(process.cwd());
+    // Inspect every capability before registering anything to avoid a partial load.
+    selected = CAPABILITIES.map((capability) =>
+      initial.inspectCapability(capability),
+    ).filter((inspection) => inspection.provider);
+  } catch (error) {
+    if (
+      !(error instanceof WebfoxError) ||
+      !["INVALID_CONFIG", "INVALID_INPUT", "PROVIDER_UNAVAILABLE"].includes(
+        error.code,
+      )
+    )
+      throw error;
+    const message = `✘︎ Web extension disabled: ${error.message}\nFix the configuration, then restart pi or run /reload.`;
+    pi.on("session_start", (_event, context) => {
+      if (context.hasUI) context.ui.notify(message, "error");
+      else console.error(message);
+    });
+    return;
+  }
   if (!selected.length)
     pi.on("session_start", (_event, context) => {
       if (context.hasUI)
@@ -40,8 +59,8 @@ export default function webExtension(pi: ExtensionAPI): void {
           "warning",
         );
     });
-  for (const capability of selected) {
-    const inspection = initial.inspectCapability(capability);
+  for (const inspection of selected) {
+    const capability = inspection.capability;
     const provider = inspection.provider!;
     const fields: TProperties =
       capability === "contents"

--- a/test/pi-diagnostics.test.ts
+++ b/test/pi-diagnostics.test.ts
@@ -1,0 +1,38 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { expect, it } from "vitest";
+import { parseConfig } from "../src/configuration/file.js";
+import { WebfoxError } from "../src/errors.js";
+import { configurationDiagnostic } from "../src/pi-diagnostics.js";
+
+it("renders a compact diagnostic for an unknown key without duplicate schema errors", () => {
+  let error: unknown;
+  try {
+    parseConfig("deafaults: {}", join(homedir(), ".config/webfox/config.yaml"));
+  } catch (caught) {
+    error = caught;
+  }
+  expect(error).toBeInstanceOf(WebfoxError);
+  expect(configurationDiagnostic(error as WebfoxError)).toBe(
+    "Webfox disabled — invalid configuration\n" +
+      "  ~/.config/webfox/config.yaml\n" +
+      "  Unknown key: deafaults\n\n" +
+      "Fix the configuration, then /reload.",
+  );
+});
+
+it("reports nested unknown keys without showing their values", () => {
+  let error: unknown;
+  try {
+    parseConfig(
+      "defaults:\n  search:\n    typo: private-secret",
+      "/tmp/config.yaml",
+    );
+  } catch (caught) {
+    error = caught;
+  }
+  expect(error).toBeInstanceOf(WebfoxError);
+  const message = configurationDiagnostic(error as WebfoxError);
+  expect(message).toContain("Unknown key: defaults.search.typo");
+  expect(message).not.toContain("private-secret");
+});

--- a/test/pi.test.ts
+++ b/test/pi.test.ts
@@ -14,6 +14,7 @@ vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => ({
 const paths: string[] = [];
 afterEach(async () => {
   vi.unstubAllEnvs();
+  vi.restoreAllMocks();
   await Promise.all(
     paths.splice(0).map((path) => rm(path, { recursive: true, force: true })),
   );
@@ -181,6 +182,68 @@ it("rejects misplaced provider parameters before execution with a repair hint", 
   );
   expect(execute).not.toHaveBeenCalled();
 });
+
+it.each([
+  ["malformed YAML", "providers: [private-secret", "Invalid YAML"],
+  ["invalid schema", "defaults: false", "Invalid"],
+  [
+    "invalid provider options",
+    "providers:\n  exa:\n    options:\n      search:\n        type: private-secret\n",
+    "/providers/exa/options/search/type",
+  ],
+  [
+    "unsupported default capability",
+    "defaults:\n  search:\n    provider: brave\n  research:\n    provider: serper\n",
+    "/defaults/research/provider",
+  ],
+  ["missing explicit file", undefined, "Could not read configuration"],
+])(
+  "disables the extension for %s without blocking startup",
+  async (_name, config, diagnostic) => {
+    const directory = await mkdtemp(join(tmpdir(), "web-pi-invalid-"));
+    paths.push(directory);
+    const path = join(directory, "config.yaml");
+    if (config !== undefined) await writeFile(path, config);
+    vi.stubEnv("WEBFOX_CONFIG", path);
+    const notify = vi.fn();
+    const stderr = vi.spyOn(console, "error").mockImplementation(() => {});
+    const stdout = vi.spyOn(console, "log").mockImplementation(() => {});
+    const registerTool = vi.fn();
+    const events: Record<string, (...args: any[]) => any> = {};
+    const pi = {
+      registerTool,
+      on: (name: string, handler: any) => {
+        events[name] = handler;
+      },
+    } as any;
+
+    expect(() => webExtension(pi)).not.toThrow();
+    expect(registerTool).not.toHaveBeenCalled();
+    expect(Object.keys(events)).toEqual(["session_start"]);
+    expect(stderr).not.toHaveBeenCalled();
+    events.session_start({}, { hasUI: true, ui: { notify } });
+    expect(notify).toHaveBeenCalledExactlyOnceWith(
+      expect.stringMatching(/^✘︎ Web extension disabled: /),
+      "error",
+    );
+    const message = notify.mock.calls[0][0];
+    expect(message).toContain(diagnostic);
+    expect(message.match(/✘︎/g)).toHaveLength(1);
+    expect(message).toContain("restart pi or run /reload");
+    expect(message).not.toContain("private-secret");
+    expect(stderr).not.toHaveBeenCalled();
+    // Print/JSON modes must report on stderr without relying on UI or polluting stdout.
+    events.session_start({}, { hasUI: false });
+    expect(stderr).toHaveBeenCalledExactlyOnceWith(message);
+    expect(stdout).not.toHaveBeenCalled();
+
+    // A fresh extension load after repair must register tools normally.
+    await writeFile(path, "defaults:\n  search:\n    provider: brave\n");
+    webExtension(pi);
+    expect(registerTool).toHaveBeenCalledOnce();
+    expect(registerTool.mock.calls[0][0].name).toBe("web_search");
+  },
+);
 
 it("keeps unconfigured notifications generic", async () => {
   const directory = await mkdtemp(join(tmpdir(), "web-pi-"));

--- a/test/pi.test.ts
+++ b/test/pi.test.ts
@@ -185,7 +185,8 @@ it("rejects misplaced provider parameters before execution with a repair hint", 
 
 it.each([
   ["malformed YAML", "providers: [private-secret", "Invalid YAML"],
-  ["invalid schema", "defaults: false", "Invalid"],
+  ["invalid schema", "defaults: false", "/defaults: must be object"],
+  ["unknown key", "deafaults: {}", "Unknown key: deafaults"],
   [
     "invalid provider options",
     "providers:\n  exa:\n    options:\n      search:\n        type: private-secret\n",
@@ -196,7 +197,7 @@ it.each([
     "defaults:\n  search:\n    provider: brave\n  research:\n    provider: serper\n",
     "/defaults/research/provider",
   ],
-  ["missing explicit file", undefined, "Could not read configuration"],
+  ["missing explicit file", undefined, "Could not read file"],
 ])(
   "disables the extension for %s without blocking startup",
   async (_name, config, diagnostic) => {
@@ -223,13 +224,19 @@ it.each([
     expect(stderr).not.toHaveBeenCalled();
     events.session_start({}, { hasUI: true, ui: { notify } });
     expect(notify).toHaveBeenCalledExactlyOnceWith(
-      expect.stringMatching(/^✘︎ Web extension disabled: /),
+      expect.stringMatching(/^Webfox disabled — invalid configuration\n/),
       "error",
     );
     const message = notify.mock.calls[0][0];
     expect(message).toContain(diagnostic);
-    expect(message.match(/✘︎/g)).toHaveLength(1);
-    expect(message).toContain("restart pi or run /reload");
+    expect(message).not.toContain("✘︎");
+    expect(message).toContain(`\n  ${path}\n`);
+    expect(message.endsWith("\n\nFix the configuration, then /reload.")).toBe(
+      true,
+    );
+    expect(message).not.toMatch(
+      /schema is false|additional properties|Provider options belong/,
+    );
     expect(message).not.toContain("private-secret");
     expect(stderr).not.toHaveBeenCalled();
     // Print/JSON modes must report on stderr without relying on UI or polluting stdout.


### PR DESCRIPTION
## 🔍 Problem

- Invalid Webfox configuration escapes extension initialization instead of leaving Pi usable without web tools.

## 🛠️ Solution

- Validate configuration and inspect capabilities before registering tools.
- Show a structured error notification with the file path, actionable issues, and a reload hint; use stderr in print/JSON modes.
- Summarize unknown keys without duplicate schema errors, unrelated hints, or an extra error glyph.
- Register no web tools on configuration failure; preserve existing CLI and library error messages.

## 💬 Review

- Regression coverage includes malformed YAML, schema errors, invalid provider options, unsupported defaults, missing files, unknown keys, and loading after repair.
- All 354 tests, type checks, formatting, build, and changelog validation pass.