### PR TITLE
Replace the Gemini SDK with direct HTTP calls

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "webfox",
       "dependencies": {
-        "@google/genai": "^2.21.0",
         "@mendable/firecrawl-js": "^4.38.0",
         "@perplexity-ai/perplexity_ai": "^0.38.5",
         "@tavily/core": "^0.7.9",
@@ -177,7 +176,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g=="],
 
-    "@google/genai": ["@google/genai@2.21.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-+PDtco2/Z0ONdzCGekCoCT+O1VJS9xJQNN4XzQpXG/t3El/SWWMkCWlFRO1KmivOHPa4Q0VjUYu1HBKCZ/v33Q=="],
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.6.0", "", {}, "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw=="],
 
@@ -227,7 +226,7 @@
 
     "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
 
-    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
 
     "@rolldown/binding-android-arm-eabi": ["@rolldown/binding-android-arm-eabi@1.2.7", "", { "os": "android", "cpu": "arm" }, "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ=="],
 
@@ -449,7 +448,7 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
-    "gaxios": ["gaxios@7.3.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ=="],
+    "gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
 
     "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
 
@@ -459,7 +458,7 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
-    "google-auth-library": ["google-auth-library@10.9.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw=="],
+    "google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
@@ -573,7 +572,7 @@
 
     "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
-    "protobufjs": ["protobufjs@7.6.6", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg=="],
+    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
@@ -741,13 +740,13 @@
 
     "@earendil-works/pi-agent-core/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
-    "@earendil-works/pi-ai/@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
-
     "@earendil-works/pi-ai/openai": ["openai@6.40.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" } }, "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA=="],
 
     "@earendil-works/pi-ai/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
     "@earendil-works/pi-coding-agent/typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
+
+    "@google/genai/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "@smithy/credential-provider-imds/@smithy/core": ["@smithy/core@3.33.3", "", { "dependencies": { "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg=="],
 
@@ -763,9 +762,9 @@
 
     "gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
-    "gcp-metadata/gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
-
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "protobufjs/@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
 
     "valyu-js/axios": ["axios@1.20.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.6", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg=="],
 
@@ -887,30 +886,14 @@
 
     "@earendil-works/chord/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
-    "@earendil-works/pi-ai/@google/genai/google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
-
-    "@earendil-works/pi-ai/@google/genai/protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
-
-    "@earendil-works/pi-ai/@google/genai/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
-
     "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
-    "gcp-metadata/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+    "protobufjs/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "valyu-js/axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "@aws-sdk/client-bedrock-runtime/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.41", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ=="],
 
-    "@earendil-works/pi-ai/@google/genai/google-auth-library/gaxios": ["gaxios@7.1.4", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA=="],
-
-    "@earendil-works/pi-ai/@google/genai/protobufjs/@protobufjs/utf8": ["@protobufjs/utf8@1.1.1", "", {}, "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="],
-
-    "@earendil-works/pi-ai/@google/genai/protobufjs/@types/node": ["@types/node@22.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew=="],
-
     "valyu-js/axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
-
-    "@earendil-works/pi-ai/@google/genai/google-auth-library/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
-
-    "@earendil-works/pi-ai/@google/genai/protobufjs/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
   }
 }

--- a/changelog/unreleased/lighter-gemini-installation.md
+++ b/changelog/unreleased/lighter-gemini-installation.md
@@ -8,4 +8,4 @@ prs:
 created: 2026-09-08T09:42:40.028854Z
 ---
 
-Gemini grounded answers and deep research now require fewer installation dependencies, without changing your API key, model settings, or commands. Webfox no longer brings in Google's SDK and its installation scripts for Gemini access. Pi or other installed packages may still require those dependencies separately.
+Gemini grounded answers and deep research now require fewer installation dependencies, without changing your API key, model settings, or commands. Webfox no longer brings in Google's SDK and its installation scripts for Gemini access.

--- a/changelog/unreleased/lighter-gemini-installation.md
+++ b/changelog/unreleased/lighter-gemini-installation.md
@@ -1,0 +1,9 @@
+---
+title: Lighter Gemini installation
+type: change
+authors:
+  - mavam
+created: 2026-09-08T09:41:29.671055Z
+---
+
+Gemini grounded answers and deep research now require fewer installation dependencies, without changing your API key, model settings, or commands. Webfox no longer brings in Google's SDK and its installation scripts for Gemini access. Pi or other installed packages may still require those dependencies separately.

--- a/changelog/unreleased/lighter-gemini-installation.md
+++ b/changelog/unreleased/lighter-gemini-installation.md
@@ -1,6 +1,6 @@
 ---
 title: Lighter Gemini installation
-type: change
+type: bugfix
 authors:
   - mavam
 prs:

--- a/changelog/unreleased/lighter-gemini-installation.md
+++ b/changelog/unreleased/lighter-gemini-installation.md
@@ -3,7 +3,9 @@ title: Lighter Gemini installation
 type: change
 authors:
   - mavam
-created: 2026-09-08T09:41:29.671055Z
+prs:
+  - 43
+created: 2026-09-08T09:42:40.028854Z
 ---
 
 Gemini grounded answers and deep research now require fewer installation dependencies, without changing your API key, model settings, or commands. Webfox no longer brings in Google's SDK and its installation scripts for Gemini access. Pi or other installed packages may still require those dependencies separately.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
-        "@google/genai": "^2.21.0",
         "@mendable/firecrawl-js": "^4.38.0",
         "@perplexity-ai/perplexity_ai": "^0.38.5",
         "@tavily/core": "^0.7.9",
@@ -3654,30 +3653,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@google/genai": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.21.0.tgz",
-      "integrity": "sha512-+PDtco2/Z0ONdzCGekCoCT+O1VJS9xJQNN4XzQpXG/t3El/SWWMkCWlFRO1KmivOHPa4Q0VjUYu1HBKCZ/v33Q==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
@@ -3730,30 +3705,35 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
@@ -3763,24 +3743,28 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
       "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm-eabi": {
@@ -4245,6 +4229,7 @@
       "version": "26.4.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.1.tgz",
       "integrity": "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -4254,6 +4239,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -4813,6 +4799,7 @@
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -4829,6 +4816,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/call-bind-apply-helpers": {
@@ -4904,6 +4892,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4975,6 +4964,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -5141,6 +5131,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-sha256": {
@@ -5172,6 +5163,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5276,6 +5268,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -5312,6 +5305,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
       "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -5326,6 +5320,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -5344,6 +5339,7 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
       "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "gaxios": "^7.0.0",
@@ -5408,6 +5404,7 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
       "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -5425,6 +5422,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -5521,6 +5519,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
@@ -5544,6 +5543,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -5555,6 +5555,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.1",
@@ -5874,6 +5875,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/magic-string": {
@@ -5938,6 +5940,7 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6028,6 +6031,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.0",
@@ -6109,6 +6113,7 @@
       "version": "7.6.6",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
       "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6141,6 +6146,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -6184,6 +6190,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6357,6 +6364,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/valyu-js": {
@@ -6577,6 +6585,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -6619,6 +6628,7 @@
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
       "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@google/genai": "^2.21.0",
     "@mendable/firecrawl-js": "^4.38.0",
     "@perplexity-ai/perplexity_ai": "^0.38.5",
     "@tavily/core": "^0.7.9",

--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -2115,7 +2115,7 @@
                               "type": "string"
                             }
                           },
-                          "description": "Request labels to attach to the Gemini call."
+                          "description": "Unsupported by the Gemini Developer API; requests with labels are rejected."
                         },
                         "temperature": {
                           "type": "number",

--- a/src/providers/gemini/adapter.ts
+++ b/src/providers/gemini/adapter.ts
@@ -1,4 +1,4 @@
-import { GoogleGenAI } from "@google/genai";
+import { httpError } from "../../errors.js";
 
 import { executeAsyncResearch } from "../../runtime/polling.js";
 import type {
@@ -19,7 +19,6 @@ export const geminiImplementation = {
     context: ProviderContext,
     options?: Record<string, unknown>,
   ): Promise<ToolOutput> {
-    const ai = this.createClient(config);
     const request = buildGeminiGenerateContentRequest({
       defaultModel: DEFAULT_ANSWER_MODEL,
       prompt: query,
@@ -27,17 +26,32 @@ export const geminiImplementation = {
       toolConfig: { googleSearch: {} },
     });
 
-    const response = await ai.models.generateContent({
-      model: request.model,
-      contents: request.contents,
-      config: addAbortSignalToGeminiConfig(request.config, context.signal),
-    });
-
-    const lines: string[] = [];
-    lines.push(response.text?.trim() || "No answer returned.");
+    const response = await requestGemini(
+      `models/${encodeURIComponent(request.model.replace(/^models\//, ""))}:generateContent`,
+      config,
+      context,
+      request.body,
+    );
+    const candidate = Array.isArray(response.candidates)
+      ? asRecord(response.candidates[0])
+      : {};
+    const parts = asRecord(candidate.content).parts;
+    const text = Array.isArray(parts)
+      ? parts
+          .filter(
+            (part) =>
+              isPlainObject(part) &&
+              !part.thought &&
+              typeof part.text === "string",
+          )
+          .map((part) => part.text)
+          .join("")
+          .trim()
+      : "";
+    const lines: string[] = [text || "No answer returned."];
 
     const sources = extractGroundingSources(
-      response.candidates?.[0]?.groundingMetadata?.groundingChunks,
+      asRecord(candidate.groundingMetadata).groundingChunks,
     );
     if (sources.length > 0) {
       lines.push("");
@@ -80,19 +94,25 @@ export const geminiImplementation = {
     context: ProviderContext,
     options?: Record<string, unknown>,
   ): Promise<ResearchJob> {
-    const ai = this.createClient(config);
     const requestOptions = getGeminiResearchRequestOptions(options);
-    const interaction = await ai.interactions.create(
+    const interaction = await requestGemini(
+      "interactions",
+      config,
+      context,
       {
         ...requestOptions,
         input,
         agent: DEFAULT_RESEARCH_AGENT,
         background: true,
       },
-      buildGeminiRequestOptions(context.signal, context.idempotencyKey),
+      context.idempotencyKey,
     );
 
-    return { id: interaction.id };
+    const id = readNonEmptyString(interaction.id);
+    if (!id) {
+      throw new Error("Gemini research response is missing an interaction ID.");
+    }
+    return { id };
   },
 
   async pollResearch(
@@ -101,11 +121,10 @@ export const geminiImplementation = {
     context: ProviderContext,
     _options?: Record<string, unknown>,
   ): Promise<ResearchPollResult> {
-    const ai = this.createClient(config);
-    const interaction = await ai.interactions.get(
-      id,
-      undefined,
-      buildGeminiRequestOptions(context.signal),
+    const interaction = await requestGemini(
+      `interactions/${encodeURIComponent(id)}`,
+      config,
+      context,
     );
 
     const status = readNonEmptyString(interaction.status) ?? "unknown";
@@ -153,43 +172,56 @@ export const geminiImplementation = {
       ? { status: "in_progress" }
       : { status: "in_progress", statusText: status };
   },
-
-  createClient(config: Gemini): GoogleGenAI {
-    const apiKey = config.credentials?.api;
-    if (!apiKey) {
-      throw new Error("is missing an API key");
-    }
-
-    return new GoogleGenAI({
-      httpOptions: { retryOptions: { attempts: 1 } },
-      apiKey,
-    });
-  },
 };
 
-function buildGeminiRequestOptions(
-  signal: AbortSignal | undefined,
+// Keep retries in Webfox's runtime, not in the transport: submissions can bill.
+async function requestGemini(
+  path: string,
+  config: Gemini,
+  context: ProviderContext,
+  body?: Record<string, unknown>,
   idempotencyKey?: string,
-) {
-  return {
-    maxRetries: 0,
-    ...(signal ? { signal } : {}),
-    ...(idempotencyKey ? { idempotencyKey } : {}),
-  };
+): Promise<Record<string, unknown>> {
+  const apiKey = config.credentials?.api;
+  if (!apiKey) throw new Error("is missing an API key");
+
+  const response = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/${path}`,
+    {
+      method: body === undefined ? "GET" : "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-goog-api-key": apiKey,
+        ...(idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {}),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+      signal: context.signal,
+    },
+  );
+  if (!response.ok) {
+    const text = (await response.text()).trim();
+    let detail = text;
+    try {
+      const error = asRecord(asRecord(JSON.parse(text)).error);
+      detail = readNonEmptyString(error.message) ?? text;
+    } catch {
+      // Proxies may return plain text rather than a Google JSON error.
+    }
+    detail = detail.replaceAll(apiKey, "[redacted]").slice(0, 1000);
+    throw httpError(
+      response,
+      `Gemini API request failed (${response.status})${detail ? `: ${detail}` : "."}`,
+    );
+  }
+  const payload: unknown = await response.json();
+  if (!isPlainObject(payload)) {
+    throw new Error("Gemini API returned an invalid response.");
+  }
+  return payload;
 }
 
-function addAbortSignalToGeminiConfig(
-  config: Record<string, unknown> | undefined,
-  signal: AbortSignal | undefined,
-): Record<string, unknown> | undefined {
-  if (!signal) {
-    return config;
-  }
-
-  return {
-    ...(config ?? {}),
-    abortSignal: signal,
-  };
+function asRecord(value: unknown): Record<string, unknown> {
+  return isPlainObject(value) ? value : {};
 }
 
 function readInteractionSteps(interaction: unknown): unknown {
@@ -338,20 +370,37 @@ function buildGeminiGenerateContentRequest({
   toolConfig: { googleSearch: {} };
 }): {
   model: string;
-  contents: string;
-  config: Record<string, unknown>;
+  body: Record<string, unknown>;
 } {
   const requestOptions = isPlainObject(options) ? options : {};
   const explicitConfig = isPlainObject(requestOptions.config)
     ? requestOptions.config
     : {};
 
+  // Labels were rejected by the SDK for the Developer API too.
+  if (explicitConfig.labels !== undefined) {
+    throw new Error(
+      "Gemini answer config.labels is not supported by the Gemini Developer API.",
+    );
+  }
+  const generationConfig = Object.fromEntries(
+    [
+      "thinkingConfig",
+      "temperature",
+      "topP",
+      "topK",
+      "candidateCount",
+      "maxOutputTokens",
+    ]
+      .filter((key) => explicitConfig[key] !== undefined)
+      .map((key) => [key, explicitConfig[key]]),
+  );
   return {
     model: readNonEmptyString(requestOptions.model) ?? defaultModel,
-    contents: prompt,
-    config: {
-      ...explicitConfig,
+    body: {
+      contents: [{ role: "user", parts: [{ text: prompt }] }],
       tools: [toolConfig],
+      ...(Object.keys(generationConfig).length ? { generationConfig } : {}),
     },
   };
 }

--- a/src/providers/gemini/definition.ts
+++ b/src/providers/gemini/definition.ts
@@ -3,7 +3,7 @@ import { defineProvider } from "../definition.js";
 export const geminiProvider = defineProvider({
   id: "gemini",
   label: "Gemini",
-  docsUrl: "https://github.com/googleapis/js-genai",
+  docsUrl: "https://ai.google.dev/api",
   local: false,
   credentials: [
     {
@@ -60,7 +60,8 @@ export const geminiProvider = defineProvider({
                     type: "string",
                   },
                 },
-                description: "Request labels to attach to the Gemini call.",
+                description:
+                  "Unsupported by the Gemini Developer API; requests with labels are rejected.",
               },
               temperature: {
                 type: "number",

--- a/test/gemini-provider.test.ts
+++ b/test/gemini-provider.test.ts
@@ -1,11 +1,29 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   adapter,
-  geminiImplementation,
+  geminiImplementation as provider,
 } from "../src/providers/gemini/adapter.js";
 import { createWebfox, parseConfig } from "../src/index.js";
-import type { Gemini } from "../src/providers/gemini/types.js";
+import { asWebfoxError } from "../src/errors.js";
 import type { ProviderContext } from "../src/providers/contract.js";
+
+const config = { credentials: { api: "literal-key" } };
+const context: ProviderContext = { cwd: process.cwd() };
+const base = "https://generativelanguage.googleapis.com/v1beta/";
+
+function mockResponse(payload: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue(Response.json(payload));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function requestBody(fetchMock: ReturnType<typeof mockResponse>) {
+  return JSON.parse(fetchMock.mock.calls[0]![1].body);
+}
+
+function answerPayload(text = "Answer") {
+  return { candidates: [{ content: { parts: [{ text }] } }] };
+}
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -13,20 +31,21 @@ afterEach(() => {
 });
 
 describe("Gemini capability boundaries", () => {
-  it("offers answers and research, not standalone search", async () => {
+  it("offers answers and research, not standalone search or contents", async () => {
     const client = createWebfox({
       config: {},
       env: { GOOGLE_API_KEY: "test-key" },
     });
-    const provider = client.getProvider("gemini")!;
-    expect(provider.capabilities).toEqual(["answer", "research"]);
-    expect(provider.configured).toEqual(["answer", "research"]);
+    const info = client.getProvider("gemini")!;
+    expect(info.capabilities).toEqual(["answer", "research"]);
+    expect(info.configured).toEqual(["answer", "research"]);
     expect("search" in adapter).toBe(false);
-    expect("search" in geminiImplementation).toBe(false);
+    expect("contents" in provider).toBe(false);
     await expect(
       client.search({ provider: "gemini", queries: ["test"] }),
     ).rejects.toThrow("does not support search");
   });
+
   it("rejects obsolete Gemini search configuration", () => {
     expect(() =>
       createWebfox({
@@ -39,371 +58,358 @@ describe("Gemini capability boundaries", () => {
   });
 });
 
-describe("Gemini provider answer", () => {
+describe("Gemini HTTP answers", () => {
   it("defaults to Gemini 3.8 Flash with Google Search grounding", async () => {
-    const generateContent = vi
-      .fn()
-      .mockResolvedValue({ text: "Answer", candidates: [] });
-    const provider = createProvider({ models: { generateContent } });
-    await provider.answer("Question", createConfig(), createContext());
-    expect(generateContent).toHaveBeenCalledWith({
-      model: "gemini-3.8-flash",
-      contents: "Question",
-      config: { tools: [{ googleSearch: {} }] },
+    const fetchMock = mockResponse(answerPayload());
+    expect(await provider.answer("Question", config, context)).toEqual({
+      provider: "gemini",
+      text: "Answer",
+      itemCount: 0,
     });
-    const client = createWebfox({ config: {}, env: {} });
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+      `${base}models/gemini-3.8-flash:generateContent`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-goog-api-key": "literal-key",
+        },
+        body: JSON.stringify({
+          contents: [{ role: "user", parts: [{ text: "Question" }] }],
+          tools: [{ googleSearch: {} }],
+        }),
+        signal: undefined,
+      },
+    );
     expect(
-      client.inspectCapability("answer", "gemini").defaults.options?.model,
+      createWebfox({ config: {}, env: {} }).inspectCapability(
+        "answer",
+        "gemini",
+      ).defaults.options?.model,
     ).toBe("gemini-3.8-flash");
   });
-  it("supports provider-specific request options for answers while keeping Google Search grounding enabled", async () => {
-    const generateContent = vi.fn().mockResolvedValue({
-      text: "Grounded answer",
-      candidates: [],
-    });
 
-    const provider = createProvider({ models: { generateContent } });
-    await provider.answer("What changed?", createConfig(), createContext(), {
-      model: "gemini-2.5-pro",
-      config: {
-        labels: {
-          route: "answer",
-        },
-        temperature: 0.1,
-        tools: [{ urlContext: {} }],
-      },
+  it("maps supported generation options and keeps grounding enabled", async () => {
+    const fetchMock = mockResponse(answerPayload());
+    const generationConfig = {
+      thinkingConfig: { thinkingLevel: "HIGH", includeThoughts: true },
+      temperature: 0,
+      topP: 0.8,
+      topK: 10,
+      candidateCount: 1,
+      maxOutputTokens: 512,
+    };
+    await provider.answer("Question", config, context, {
+      model: "models/gemini-2.5-pro",
+      config: { ...generationConfig, tools: [{ urlContext: {} }] },
     });
-
-    expect(generateContent).toHaveBeenCalledWith({
-      model: "gemini-2.5-pro",
-      contents: "What changed?",
-      config: {
-        labels: {
-          route: "answer",
-        },
-        temperature: 0.1,
-        tools: [{ googleSearch: {} }],
-      },
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      `${base}models/gemini-2.5-pro:generateContent`,
+    );
+    expect(requestBody(fetchMock)).toEqual({
+      contents: [{ role: "user", parts: [{ text: "Question" }] }],
+      tools: [{ googleSearch: {} }],
+      generationConfig,
     });
   });
 
-  it("suppresses opaque grounding redirect URLs and dedupes source display", async () => {
-    const provider = createProvider({
-      models: {
-        generateContent: vi.fn().mockResolvedValue({
-          text: "ACME platforms help teams route and transform operational data.",
-          candidates: [
-            {
-              groundingMetadata: {
-                groundingChunks: [
-                  {
-                    web: {
-                      title: "ACME overview",
-                      uri: "https://vertexaisearch.cloud.google.com/grounding-api-redirect/opaque-1",
-                    },
-                  },
-                  {
-                    web: {
-                      title: "ACME docs",
-                      uri: "https://example.com/docs",
-                    },
-                  },
-                  {
-                    web: {
-                      title: "ACME overview",
-                      uri: "https://vertexaisearch.cloud.google.com/grounding-api-redirect/opaque-2",
-                    },
-                  },
-                ],
-              },
-            },
-          ],
-        }),
-      },
-    });
-
-    const response = await provider.answer(
-      "ACME platform use cases",
-      createConfig(),
-      createContext(),
-      undefined,
-    );
-
-    expect(response.text).toContain(
-      "ACME platforms help teams route and transform operational data.",
-    );
-    expect(response.text).toContain("Sources:\n1. ACME overview\n2. ACME docs");
-    expect(response.text).toContain("   https://example.com/docs");
-    expect(response.text).not.toContain("vertexaisearch.cloud.google.com");
-    expect(response.itemCount).toBe(2);
-  });
-});
-
-it("does not expose a contents handler", () => {
-  expect("contents" in geminiImplementation).toBe(false);
-});
-
-describe("Gemini provider research", () => {
-  it("starts Gemini deep research with supported request options", async () => {
-    const create = vi.fn().mockResolvedValue({ id: "research-1" });
-
-    const provider = createProvider({
-      interactions: {
-        create,
-      },
-    });
-
-    const job = await provider.startResearch!(
-      "Investigate ACME platform use cases",
-      createConfig(),
-      { ...createContext(), idempotencyKey: "stable-key" },
-      undefined,
-    );
-
-    expect(job).toEqual({ id: "research-1" });
-    expect(create).toHaveBeenCalledWith(
-      {
-        input: "Investigate ACME platform use cases",
-        agent: "deep-research-preview-04-2026",
-        background: true,
-      },
-      { idempotencyKey: "stable-key", maxRetries: 0 },
-    );
-  });
-
-  it("rejects unsupported Gemini deep-research options", async () => {
-    const create = vi.fn().mockResolvedValue({ id: "research-1" });
-    const provider = createProvider({ interactions: { create } });
-
+  it("preserves the SDK's rejection of Developer API labels", async () => {
+    const fetchMock = mockResponse({});
     await expect(
-      provider.startResearch!(
-        "Investigate ACME platform use cases",
-        createConfig(),
-        createContext(),
-        { tools: [] },
-      ),
-    ).rejects.toThrow("Unsupported Gemini research options: tools.");
-    expect(create).not.toHaveBeenCalled();
+      provider.answer("Question", config, context, {
+        config: { labels: { route: "answer" } },
+      }),
+    ).rejects.toThrow("config.labels is not supported");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("rejects unsupported Gemini deep-research agent configuration", async () => {
-    const create = vi.fn().mockResolvedValue({ id: "research-1" });
-    const provider = createProvider({ interactions: { create } });
-
-    await expect(
-      provider.startResearch!(
-        "Investigate ACME platform use cases",
-        createConfig(),
-        createContext(),
+  it("joins text from the first candidate and excludes thoughts and non-text parts", async () => {
+    mockResponse({
+      candidates: [
         {
-          agent_config: {
-            response_length: "short",
+          content: {
+            parts: [
+              { text: "Private", thought: true },
+              { text: "Hello " },
+              { inlineData: {} },
+              { text: "world" },
+            ],
           },
         },
-      ),
-    ).rejects.toThrow(
-      "Unsupported Gemini agent_config options: response_length.",
-    );
-    expect(create).not.toHaveBeenCalled();
-  });
-
-  it("forwards supported Gemini deep-research agent configuration", async () => {
-    const create = vi.fn().mockResolvedValue({ id: "research-1" });
-
-    const provider = createProvider({
-      interactions: {
-        create,
-      },
+        { content: { parts: [{ text: "Alternative" }] } },
+      ],
     });
-
-    await provider.startResearch!(
-      "Investigate ACME platform use cases",
-      createConfig(),
-      createContext(),
-      {
-        agent_config: {
-          thinking_summaries: "auto",
-        },
-      },
-    );
-
-    expect(create).toHaveBeenCalledWith(
-      {
-        agent_config: {
-          type: "deep-research",
-          thinking_summaries: "auto",
-        },
-        input: "Investigate ACME platform use cases",
-        agent: "deep-research-preview-04-2026",
-        background: true,
-      },
-      { maxRetries: 0 },
+    expect((await provider.answer("Question", config, context)).text).toBe(
+      "Hello world",
     );
   });
 
-  it("returns in-progress Gemini research status from polling", async () => {
-    const get = vi.fn().mockResolvedValue({ status: "in_progress" });
-
-    const provider = createProvider({
-      interactions: {
-        get,
-      },
-    });
-
-    const result = await provider.pollResearch!(
-      "research-1",
-      createConfig(),
-      createContext(),
-      undefined,
+  it.each([
+    {},
+    { candidates: [] },
+    { candidates: [{ content: { parts: [{ text: " " }] } }] },
+  ])("handles empty answer content", async (payload) => {
+    mockResponse(payload);
+    expect((await provider.answer("Question", config, context)).text).toBe(
+      "No answer returned.",
     );
-
-    expect(get).toHaveBeenCalledWith("research-1", undefined, {
-      maxRetries: 0,
-    });
-    expect(result).toEqual({ status: "in_progress" });
   });
 
-  it("formats completed Gemini research output from polling", async () => {
-    const get = vi.fn().mockResolvedValue({
-      status: "completed",
-      steps: [
-        { type: "user_input" },
+  it("suppresses opaque grounding redirects, deduplicates sources, and caps them at five", async () => {
+    mockResponse({
+      candidates: [
         {
-          type: "model_output",
-          content: [{ type: "text", text: "Research result" }],
+          content: { parts: [{ text: "Grounded answer" }] },
+          groundingMetadata: {
+            groundingChunks: [
+              {
+                web: {
+                  title: "ACME overview",
+                  uri: "https://vertexaisearch.cloud.google.com/grounding-api-redirect/opaque-1",
+                },
+              },
+              { web: { title: "ACME docs", uri: "https://example.com/docs" } },
+              {
+                web: {
+                  title: "ACME overview",
+                  uri: "https://vertexaisearch.cloud.google.com/grounding-api-redirect/opaque-2",
+                },
+              },
+              ...Array.from({ length: 6 }, (_, i) => ({
+                web: { title: `Source ${i}`, uri: `https://example.com/${i}` },
+              })),
+            ],
+          },
         },
       ],
     });
-
-    const provider = createProvider({
-      interactions: {
-        get,
-      },
-    });
-
-    const result = await provider.pollResearch!(
-      "research-1",
-      createConfig(),
-      createContext(),
-      undefined,
+    const result = await provider.answer("Question", config, context);
+    expect(result.text).toContain(
+      "Grounded answer\n\nSources:\n1. ACME overview\n2. ACME docs\n   https://example.com/docs",
     );
-
-    expect(result).toEqual({
-      status: "completed",
-      output: {
-        provider: "gemini",
-        text: "Research result",
-      },
-    });
-  });
-
-  it("maps failed Gemini research polling to a terminal status", async () => {
-    const get = vi.fn().mockResolvedValue({ status: "failed" });
-
-    const provider = createProvider({
-      interactions: {
-        get,
-      },
-    });
-
-    const result = await provider.pollResearch!(
-      "research-1",
-      createConfig(),
-      createContext(),
-      undefined,
-    );
-
-    expect(result).toEqual({
-      status: "failed",
-      error: "research failed",
-    });
-  });
-
-  it("surfaces unknown Gemini research states as progress text", async () => {
-    const get = vi.fn().mockResolvedValue({ status: "running" });
-
-    const provider = createProvider({
-      interactions: {
-        get,
-      },
-    });
-
-    const result = await provider.pollResearch!(
-      "research-1",
-      createConfig(),
-      createContext(),
-      undefined,
-    );
-
-    expect(result).toEqual({
-      status: "in_progress",
-      statusText: "running",
-    });
-  });
-
-  it("treats incomplete Gemini research as terminal failure", async () => {
-    const get = vi.fn().mockResolvedValue({ status: "incomplete" });
-
-    const provider = createProvider({
-      interactions: {
-        get,
-      },
-    });
-
-    const result = await provider.pollResearch!(
-      "research-1",
-      createConfig(),
-      createContext(),
-      undefined,
-    );
-
-    expect(result).toEqual({
-      status: "failed",
-      error: "research ended incomplete",
-    });
-  });
-
-  it("treats requires_action Gemini research as terminal failure", async () => {
-    const get = vi.fn().mockResolvedValue({
-      status: "requires_action",
-      steps: [{ type: "user_input" }, { type: "function_call" }],
-    });
-
-    const provider = createProvider({
-      interactions: {
-        get,
-      },
-    });
-
-    const result = await provider.pollResearch!(
-      "research-1",
-      createConfig(),
-      createContext(),
-      undefined,
-    );
-
-    expect(result).toEqual({
-      status: "failed",
-      error: "research requires additional action (function_call)",
-    });
+    expect(result.text).not.toContain("vertexaisearch.cloud.google.com");
+    expect(result.text).not.toContain("Source 3");
+    expect(result.itemCount).toBe(5);
   });
 });
 
-function createProvider(client: unknown) {
-  return {
-    ...geminiImplementation,
-    createClient: () => client,
-  } as typeof geminiImplementation;
-}
+describe("Gemini HTTP research", () => {
+  it("submits background research with an idempotency header", async () => {
+    const fetchMock = mockResponse({ id: "research-1" });
+    const result = await provider.startResearch("Investigate ACME", config, {
+      ...context,
+      idempotencyKey: "stable-key",
+    });
+    expect(result).toEqual({ id: "research-1" });
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(`${base}interactions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-goog-api-key": "literal-key",
+        "Idempotency-Key": "stable-key",
+      },
+      body: JSON.stringify({
+        input: "Investigate ACME",
+        agent: "deep-research-preview-04-2026",
+        background: true,
+      }),
+      signal: undefined,
+    });
+  });
 
-function createConfig(): Gemini {
-  return {
-    credentials: { api: "literal-key" },
-  };
-}
+  it("forwards supported agent configuration", async () => {
+    const fetchMock = mockResponse({ id: "research-1" });
+    await provider.startResearch("Question", config, context, {
+      agent_config: { thinking_summaries: "auto" },
+    });
+    expect(requestBody(fetchMock)).toEqual({
+      agent_config: { type: "deep-research", thinking_summaries: "auto" },
+      input: "Question",
+      agent: "deep-research-preview-04-2026",
+      background: true,
+    });
+  });
 
-function createContext(): ProviderContext {
-  return {
-    cwd: process.cwd(),
-  };
-}
+  it.each([
+    [{ tools: [] }, "Unsupported Gemini research options: tools."],
+    [
+      { agent_config: { response_length: "short" } },
+      "Unsupported Gemini agent_config options: response_length.",
+    ],
+    [
+      { agent_config: { thinking_summaries: "invalid" } },
+      "must be 'auto' or 'none'",
+    ],
+  ])(
+    "rejects unsupported research options before fetching",
+    async (options, message) => {
+      const fetchMock = mockResponse({});
+      await expect(
+        provider.startResearch("Question", config, context, options),
+      ).rejects.toThrow(message);
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([{}, { id: "" }, { id: 42 }])(
+    "rejects a missing interaction ID",
+    async (payload) => {
+      mockResponse(payload);
+      await expect(
+        provider.startResearch("Question", config, context),
+      ).rejects.toThrow("missing an interaction ID");
+    },
+  );
+
+  it("polls an encoded interaction ID without a body or idempotency header", async () => {
+    const fetchMock = mockResponse({ status: "in_progress" });
+    expect(
+      await provider.pollResearch("job/with?special#chars", config, {
+        ...context,
+        idempotencyKey: "unused",
+      }),
+    ).toEqual({ status: "in_progress" });
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+      `${base}interactions/job%2Fwith%3Fspecial%23chars`,
+      {
+        method: "GET",
+        headers: {
+          "content-type": "application/json",
+          "x-goog-api-key": "literal-key",
+        },
+        signal: undefined,
+      },
+    );
+  });
+
+  it("formats completed research from model-output steps only", async () => {
+    mockResponse({
+      status: "completed",
+      steps: [
+        { type: "user_input", content: [{ type: "text", text: "Question" }] },
+        { type: "thought", content: [{ type: "text", text: "Private" }] },
+        {
+          type: "model_output",
+          content: [
+            { type: "text", text: " Report " },
+            { type: "image" },
+            { type: "text", text: "Conclusion" },
+          ],
+        },
+      ],
+    });
+    expect(await provider.pollResearch("job", config, context)).toEqual({
+      status: "completed",
+      output: { provider: "gemini", text: "Report\n\nConclusion" },
+    });
+  });
+
+  it.each([
+    ["failed", { status: "failed", error: "research failed" }],
+    ["cancelled", { status: "cancelled", error: "research was canceled" }],
+    ["incomplete", { status: "failed", error: "research ended incomplete" }],
+    [
+      "requires_action",
+      {
+        status: "failed",
+        error: "research requires additional action (function_call)",
+      },
+    ],
+    ["running", { status: "in_progress", statusText: "running" }],
+  ])("maps research status %s", async (status, expected) => {
+    mockResponse({
+      status,
+      steps: [{ type: "user_input" }, { type: "function_call" }],
+    });
+    expect(await provider.pollResearch("job", config, context)).toEqual(
+      expected,
+    );
+  });
+});
+
+describe("Gemini HTTP failures and cancellation", () => {
+  const operations = [
+    (ctx: ProviderContext) => provider.answer("Question", config, ctx),
+    (ctx: ProviderContext) => provider.startResearch("Question", config, ctx),
+    (ctx: ProviderContext) => provider.pollResearch("job", config, ctx),
+  ];
+
+  it.each(operations)(
+    "forwards abort signals without retrying",
+    async (operation) => {
+      const controller = new AbortController();
+      const error = new DOMException("Aborted", "AbortError");
+      const fetchMock = vi.fn().mockImplementation(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            init.signal.addEventListener("abort", () => reject(error), {
+              once: true,
+            });
+          }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      const pending = operation({ ...context, signal: controller.signal });
+      controller.abort();
+      await expect(pending).rejects.toBe(error);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0]![1].signal).toBe(controller.signal);
+      expect(asWebfoxError(error).code).toBe("CANCELLED");
+    },
+  );
+
+  it.each([400, 401, 403, 408, 429, 500, 503])(
+    "classifies HTTP %s without transport retries",
+    async (status) => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(
+          Response.json({ error: { message: "Request failed" } }, { status }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+      await expect(
+        provider.startResearch("Question", config, context),
+      ).rejects.toMatchObject({
+        code: "PROVIDER_FAILURE",
+        message: `Gemini API request failed (${status}): Request failed`,
+        options: { retryable: [408, 429, 500, 503].includes(status) },
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("handles plain-text errors and bounds and redacts their details", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(`literal-key ${"x".repeat(2000)}`, { status: 502 }),
+        ),
+    );
+    const error = await provider
+      .pollResearch("job", config, context)
+      .catch(asWebfoxError);
+    expect(error).toMatchObject({
+      code: "PROVIDER_FAILURE",
+      options: { retryable: true },
+    });
+    expect((error as Error).message).toContain("[redacted]");
+    expect((error as Error).message).not.toContain("literal-key");
+    expect((error as Error).message.length).toBeLessThan(1100);
+  });
+
+  it("rejects invalid JSON response shapes", async () => {
+    mockResponse(null);
+    await expect(
+      provider.startResearch("Question", config, context),
+    ).rejects.toThrow("invalid response");
+  });
+
+  it("rejects missing credentials before fetching", async () => {
+    const fetchMock = mockResponse({});
+    await expect(provider.answer("Question", {}, context)).rejects.toThrow(
+      "missing an API key",
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/provider-option-contracts.test.ts
+++ b/test/provider-option-contracts.test.ts
@@ -1,6 +1,4 @@
 import { expect, it } from "vitest";
-import type { GenerateContentConfig } from "@google/genai";
-import { ThinkingLevel } from "@google/genai";
 import type { SearchRequest, ScrapeOptions } from "@mendable/firecrawl-js";
 import type { TavilySearchOptions, TavilyExtractOptions } from "@tavily/core";
 import type { SearchParams } from "parallel-web/resources/top-level";
@@ -12,8 +10,8 @@ import type { Capability, ProviderId } from "../src/domain.js";
 import { providers } from "../src/providers/registry.js";
 import { validateOptions } from "../src/configuration/planning.js";
 
-// SDK type checks catch upstream removals/renames; runtime checks catch drift
-// between those types and the schemas actually exposed to callers.
+// SDK type checks catch upstream removals/renames where a provider uses an SDK;
+// runtime checks validate samples against the schemas exposed to callers.
 const samples: Array<{
   provider: ProviderId;
   capability: Capability;
@@ -24,9 +22,9 @@ const samples: Array<{
     capability: "answer",
     options: {
       config: {
-        thinkingConfig: { thinkingLevel: ThinkingLevel.HIGH },
+        thinkingConfig: { thinkingLevel: "HIGH" },
         maxOutputTokens: 1024,
-      } satisfies GenerateContentConfig,
+      },
     },
   },
   {

--- a/test/research-cli.test.ts
+++ b/test/research-cli.test.ts
@@ -2,35 +2,37 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Readable, Writable } from "node:stream";
-import { expect, it, vi } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 
-vi.mock("@google/genai", () => ({
-  GoogleGenAI: class {
-    interactions = {
-      create: async () => ({ id: "opaque-research-job" }),
-      get: async () => ({
-        status: "completed",
-        steps: [
-          {
-            type: "model_output",
-            content: [
-              {
-                type: "text",
-                text: "# The question of life\n\nResearch report.",
-              },
-            ],
-          },
-        ],
-      }),
-    };
-  },
-}));
+afterEach(() => vi.unstubAllGlobals());
 
 import { runCli } from "../src/cli.js";
 
 it.each([false, true])(
   "keeps Gemini research logs on stderr and the report on stdout (quiet=%s)",
   async (quiet) => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(Response.json({ id: "opaque-research-job" }))
+        .mockResolvedValueOnce(
+          Response.json({
+            status: "completed",
+            steps: [
+              {
+                type: "model_output",
+                content: [
+                  {
+                    type: "text",
+                    text: "# The question of life\n\nResearch report.",
+                  },
+                ],
+              },
+            ],
+          }),
+        ),
+    );
     const directory = await mkdtemp(join(tmpdir(), "webfox-research-cli-"));
     try {
       const config = join(directory, "config.yaml");


### PR DESCRIPTION
## 🔍 Problem

- Gemini access pulls in `@google/genai` and its transitive dependencies and installation scripts, although Webfox only needs three HTTP operations.

## 🛠️ Solution

- Use native `fetch` for grounded answers, background research submission, and polling.
- Preserve model defaults, Google Search grounding, source formatting, research statuses, and cancellation. Keep retries outside the transport and classify HTTP failures through Webfox's error handling.
- Remove the direct SDK dependency and update both lockfiles. Pi's separate development dependency on GenAI remains.
- Replace SDK mocks with HTTP-contract tests and clarify the existing rejection of Developer API labels.

## 💬 Review

- Focus on the `generateContent` request mapping and Interactions API wire format. Research submissions remain non-retry-safe; no server-side idempotency guarantee is assumed.
- Passed: 378 tests, type checking, formatting, build, changelog validation, and package-install smoke tests.
- Live Gemini requests were not run (billable API calls).
