### PR TITLE
Show quotes directly in tool inputs

### DIFF
--- a/changelog/unreleased/readable-quotes-in-tool-input-rows.md
+++ b/changelog/unreleased/readable-quotes-in-tool-input-rows.md
@@ -1,0 +1,9 @@
+---
+title: Readable quotes in tool input rows
+type: bugfix
+authors:
+  - mavam
+created: 2026-09-08T15:45:36.629781Z
+---
+
+Tool input rows now display quotation marks directly instead of prefixing them with JSON escape backslashes. Quoted search terms and other inputs are easier to read while control characters remain safely escaped.

--- a/src/pi-render.ts
+++ b/src/pi-render.ts
@@ -60,7 +60,7 @@ function statusRows(details: unknown): InputStatus[] | undefined {
 
 /** Display-only input formatting; never interpret input as terminal markup. */
 function displayInput(value: string): string {
-  return JSON.stringify(plainText(value)).slice(1, -1);
+  return JSON.stringify(plainText(value)).slice(1, -1).replaceAll('\\"', '"');
 }
 
 export class WebCall implements Component {

--- a/test/pi-render.test.ts
+++ b/test/pi-render.test.ts
@@ -343,11 +343,11 @@ describe("vertical web rendering", () => {
     }
   });
 
-  it("escapes newlines, tabs, and quotes while stripping terminal controls from inputs", () => {
+  it("escapes control characters without escaping quotes in inputs", () => {
     const input = 'hello\n"quoted"\t\u001b[31mred\u001b[0m\u0007';
     const doc = result("search", [{ input, state: "done" }]);
     expect(renderWebResult(doc, collapsed, theme(), false).render(120)).toEqual(
-      ['✔︎ hello\\n\\"quoted\\"\\tred'],
+      ['✔︎ hello\\n"quoted"\\tred'],
     );
   });
 


### PR DESCRIPTION
## 🔍 Problem

Quoted search terms in tool input rows include unnecessary JSON escape backslashes, making the displayed query harder to read.

## 🛠️ Solution

Render quotation marks directly while preserving control-character escaping and terminal sanitization.

## 💬 Review

The regression test covers quotes alongside newlines, tabs, and terminal controls.
