### PR TITLE
Add SerpBase Google search modes

### DIFF
--- a/.github/workflows/live-smoke.yaml
+++ b/.github/workflows/live-smoke.yaml
@@ -70,6 +70,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           PARALLEL_API_KEY: ${{ secrets.PARALLEL_API_KEY }}
           PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          SERPBASE_API_KEY: ${{ secrets.SERPBASE_API_KEY }}
           SERPER_API_KEY: ${{ secrets.SERPER_API_KEY }}
           TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
           VALYU_API_KEY: ${{ secrets.VALYU_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Use different providers for different tasks:
 | [OpenAI]     |   ✔︎    |          |   ✔︎    |    ✔︎     |
 | [Parallel]   |   ✔︎    |    ✔︎     |        |          |
 | [Perplexity] |   ✔︎    |          |   ✔︎    |    ✔︎     |
+| [SerpBase]   |   ✔︎    |          |        |          |
 | [Serper]     |   ✔︎    |          |        |          |
 | [Tavily]     |   ✔︎    |    ✔︎     |        |          |
 | [Valyu]      |   ✔︎    |    ✔︎     |   ✔︎    |    ✔︎     |
@@ -150,6 +151,7 @@ Use different providers for different tasks:
 [OpenAI]: ./docs/provider.md#openai
 [Parallel]: ./docs/provider.md#parallel
 [Perplexity]: ./docs/provider.md#perplexity
+[SerpBase]: ./docs/provider.md#serpbase
 [Serper]: ./docs/provider.md#serper
 [Tavily]: ./docs/provider.md#tavily
 [Valyu]: ./docs/provider.md#valyu

--- a/changelog/unreleased/serpbase-google-search-provider.md
+++ b/changelog/unreleased/serpbase-google-search-provider.md
@@ -1,0 +1,23 @@
+---
+title: SerpBase Google search provider
+type: feature
+authors:
+  - mavam
+prs:
+  - 46
+created: 2026-09-10T08:18:46.12072Z
+---
+
+You can now use your SerpBase API key for Google organic searches in the CLI,
+TypeScript library, and Pi extension. Set `SERPBASE_API_KEY` or configure
+`providers.serpbase.credentials.api`, then select the provider:
+
+```sh
+web search "Node.js release notes" --provider serpbase --gl us --hl en --device pc
+web config default search serpbase
+```
+
+Choose a country, language, device, and results page without changing your search
+workflow. Each query fetches one page and preserves its organic ordering, with
+ranks and available SERP context retained in JSON metadata. `maxResults` limits
+that page locally; it doesn't trigger additional billed pages.

--- a/changelog/unreleased/serpbase-google-search-provider.md
+++ b/changelog/unreleased/serpbase-google-search-provider.md
@@ -5,19 +5,28 @@ authors:
   - mavam
 prs:
   - 46
-created: 2026-09-10T08:18:46.12072Z
+created: 2026-09-10T08:56:09.121057Z
 ---
 
-You can now use your SerpBase API key for Google organic searches in the CLI,
-TypeScript library, and Pi extension. Set `SERPBASE_API_KEY` or configure
-`providers.serpbase.credentials.api`, then select the provider:
+You can now use your SerpBase API key for Google search, images, news, videos,
+Maps Search, and place details through the existing CLI, TypeScript library, and
+Pi `web_search` tool. Set `SERPBASE_API_KEY` or configure
+`providers.serpbase.credentials.api`, then select a search mode:
 
 ```sh
-web search "Node.js release notes" --provider serpbase --gl us --hl en --device pc
+web search "Node.js release notes" --provider serpbase --mode news
+web search "coffee in Berlin" --provider serpbase --mode maps
 web config default search serpbase
 ```
 
-Choose a country, language, device, and results page without changing your search
-workflow. Each query fetches one page and preserves its organic ordering, with
-ranks and available SERP context retained in JSON metadata. `maxResults` limits
-that page locally; it doesn't trigger additional billed pages.
+For place details, pass a `feature_id` returned by Maps Search as the search input
+with `--mode maps-detail`. In Pi, put these IDs in `queries`; no additional tool
+is needed. Model-visible output includes feature IDs, contact information, and
+media URLs so follow-up calls don't depend on hidden metadata.
+
+Choose a country, language, device, page, or map center as supported by the
+selected mode. Mode changes drop incompatible inherited defaults; explicitly
+incompatible options are rejected. Each input fetches one page or place and
+preserves result order, with original ranks and available context retained in
+JSON metadata. `maxResults` limits the result locally and doesn't trigger
+additional billed pages.

--- a/changelog/unreleased/serpbase-google-search-provider.md
+++ b/changelog/unreleased/serpbase-google-search-provider.md
@@ -5,7 +5,7 @@ authors:
   - mavam
 prs:
   - 46
-created: 2026-09-10T08:56:09.121057Z
+created: 2026-09-10T11:25:30.364726Z
 ---
 
 You can now use your SerpBase API key for Google search, images, news, videos,
@@ -30,3 +30,7 @@ incompatible options are rejected. Each input fetches one page or place and
 preserves result order, with original ranks and available context retained in
 JSON metadata. `maxResults` limits the result locally and doesn't trigger
 additional billed pages.
+
+SerpBase requests have a 120-second overall deadline by default to accommodate
+slower endpoints. Explicit request or execution timeouts still take precedence;
+other providers keep their existing defaults.

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -175,6 +175,12 @@ Choose a mode with `--mode` in the CLI or `options.mode` in the library and Pi:
 | `maps` | Place search text | Places, addresses, ratings, and feature IDs; optional `lat`, `lng`, and `zoom`. |
 | `maps-detail` | Feature IDs from `maps` | One place's details per input, including contact information and hours when available. |
 
+SerpBase has a 120-second overall deadline by default because some endpoints can
+exceed the usual 30-second search deadline. An explicit CLI `--timeout`, library
+`timeoutMs`, or YAML `execution.timeoutMs` takes precedence. This deadline includes
+all inputs and retries; it isn't a separate allowance per request. Other providers
+keep their existing defaults.
+
 Every mode accepts `hl` (language, default `en`) and `gl` (country, default `us`).
 All modes except `maps-detail` accept `page` (1-based, default `1`). Maps Search
 requires `lat` and `lng` together. `zoom` requires coordinates, ranges from `1` to

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -152,6 +152,49 @@ Supports search, grounded answers, and research. Set `PERPLEXITY_API_KEY`.
 web answer "What is MCP?" --provider perplexity
 ```
 
+## SerpBase
+
+Supports Google organic search. Set `SERPBASE_API_KEY`, or configure
+`providers.serpbase.credentials.api` with a credential source. No defaults change
+unless you select SerpBase.
+
+```sh
+web search "Node.js release notes" --provider serpbase --gl us --hl en --device pc
+web config default search serpbase
+```
+
+The native options are `hl` (language, default `en`), `gl` (country, default `us`),
+`page` (1-based, default `1`), and `device` (`default`, `pc`, or `mobile`).
+`default` lets SerpBase choose the device. Save provider-specific defaults under
+`providers.serpbase.options.search`:
+
+```yaml
+providers:
+  serpbase:
+    options:
+      search:
+        gl: de
+        hl: de
+        device: pc
+```
+
+Each query fetches only the selected page, preserving the organic result order.
+`maxResults` trims that page locally; it doesn't increase the upstream page size
+or fetch additional pages. Use `--page 2` to request another page explicitly.
+Requests can incur charges, including retries after transient failures.
+
+JSON output retains each result's original `rank`, available aliases and sitelinks
+in `metadata`. Ranks are page-relative, not calculated absolute positions.
+`metadata.searchContext` includes the returned page, query, request ID, charged
+credits, and rich SERP modules such as People Also Ask and related searches when
+available. Context is attached to organic results, so an empty results list has
+no context metadata. Rich modules aren't mixed into the organic ordering.
+
+The provider uses the [JSON API](https://serpbase.dev/docs) directly, without an
+SDK dependency. `providers.serpbase.baseUrl` can replace the API origin for a
+compatible proxy; webfox appends `/google/search`. Images, news, videos, and Maps
+endpoints aren't exposed by this integration.
+
 ## Serper
 
 Supports search. Set `SERPER_API_KEY`.

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -154,7 +154,8 @@ web answer "What is MCP?" --provider perplexity
 
 ## SerpBase
 
-Supports Google organic search. Set `SERPBASE_API_KEY`, or configure
+Supports all six Google endpoints through the existing `search` capability and
+Pi's `web_search` tool. Set `SERPBASE_API_KEY`, or configure
 `providers.serpbase.credentials.api` with a credential source. No defaults change
 unless you select SerpBase.
 
@@ -163,10 +164,48 @@ web search "Node.js release notes" --provider serpbase --gl us --hl en --device 
 web config default search serpbase
 ```
 
-The native options are `hl` (language, default `en`), `gl` (country, default `us`),
-`page` (1-based, default `1`), and `device` (`default`, `pc`, or `mobile`).
-`default` lets SerpBase choose the device. Save provider-specific defaults under
-`providers.serpbase.options.search`:
+Choose a mode with `--mode` in the CLI or `options.mode` in the library and Pi:
+
+| Mode | Input | Results and controls |
+| --- | --- | --- |
+| `search` (default) | Search text | Organic results; `device` is `default`, `pc`, or `mobile`. |
+| `images` | Search text | Image URLs, source pages, and thumbnails. |
+| `news` | Search text | Articles, publishers, and published-time text. |
+| `videos` | Search text | Videos, sources, durations, and published-time text. |
+| `maps` | Place search text | Places, addresses, ratings, and feature IDs; optional `lat`, `lng`, and `zoom`. |
+| `maps-detail` | Feature IDs from `maps` | One place's details per input, including contact information and hours when available. |
+
+Every mode accepts `hl` (language, default `en`) and `gl` (country, default `us`).
+All modes except `maps-detail` accept `page` (1-based, default `1`). Maps Search
+requires `lat` and `lng` together. `zoom` requires coordinates, ranges from `1` to
+`21`, and defaults to `14` upstream when coordinates are supplied. Device
+selection applies only to organic search; `default` lets SerpBase choose.
+
+```sh
+web search "architecture diagrams" --provider serpbase --mode images
+web search "Node.js releases" --provider serpbase --mode news
+web search "Node.js tutorials" --provider serpbase --mode videos
+web search "coffee" --provider serpbase --mode maps --lat 52.52 --lng 13.405 --zoom 14
+```
+
+For place enrichment, copy a `feature_id` from a Maps result and pass it as the
+search input. Don't use a place name, `place_id`, CID, or Maps URL:
+
+```sh
+web search '0x...:0x...' --provider serpbase --mode maps-detail
+```
+
+Replace the placeholder with an actual returned ID. The model follows the same
+sequence using the same tool, with one feature ID per `queries` entry:
+
+```json
+{
+  "queries": ["0x...:0x..."],
+  "options": { "mode": "maps-detail" }
+}
+```
+
+Save provider-specific defaults under `providers.serpbase.options.search`:
 
 ```yaml
 providers:
@@ -178,22 +217,36 @@ providers:
         device: pc
 ```
 
-Each query fetches only the selected page, preserving the organic result order.
+Changing modes drops incompatible inherited defaults. For example, a request
+with `mode: images` doesn't inherit the configured `device: pc`. Explicitly
+supplying incompatible options is an error, not a silently ignored setting.
+Coordinate dependencies are checked after merging defaults and request options.
+
+Each input fetches only the selected page or place, preserving result order.
 `maxResults` trims that page locally; it doesn't increase the upstream page size
 or fetch additional pages. Use `--page 2` to request another page explicitly.
-Requests can incur charges, including retries after transient failures.
+Requests can incur charges, including retries after transient failures. See the
+[SerpBase API reference](https://serpbase.dev/docs) for per-endpoint pricing.
 
-JSON output retains each result's original `rank`, available aliases and sitelinks
-in `metadata`. Ranks are page-relative, not calculated absolute positions.
-`metadata.searchContext` includes the returned page, query, request ID, charged
-credits, and rich SERP modules such as People Also Ask and related searches when
-available. Context is attached to organic results, so an empty results list has
-no context metadata. Rich modules aren't mixed into the organic ordering.
+Text and model-visible output include actionable fields: image/source URLs,
+news/video sources and time text, and place feature IDs, addresses, contact
+information, ratings, and hours when returned. Images aren't downloaded. Published
+times and opening status are upstream observations, not independently verified.
+Ambiguous clock-like video times are labeled `Time (upstream)`, not publication
+dates or inferred durations. The known Google navigation-logo artifact is
+excluded from image results; other results retain their upstream order.
 
-The provider uses the [JSON API](https://serpbase.dev/docs) directly, without an
-SDK dependency. `providers.serpbase.baseUrl` can replace the API origin for a
-compatible proxy; webfox appends `/google/search`. Images, news, videos, and Maps
-endpoints aren't exposed by this integration.
+JSON output retains original ranks, aliases, sitelinks, media fields, and place
+data in `metadata`, alongside the selected `mode`. Ranks are page-relative, not
+calculated absolute positions. `metadata.searchContext` includes the returned
+page, query, request ID, charged credits, and rich SERP modules when available.
+Context is attached to results, so an empty results list has no context metadata.
+Rich modules aren't mixed into the primary result ordering.
+
+The provider uses the JSON API directly, without an SDK dependency.
+`providers.serpbase.baseUrl` can replace the API origin for a compatible proxy;
+webfox appends the selected endpoint, such as `/google/images` or
+`/google/maps/detail`.
 
 ## Serper
 

--- a/scripts/live-selection.mjs
+++ b/scripts/live-selection.mjs
@@ -1,3 +1,9 @@
+export function liveSearchQuery(providerId, options = {}) {
+  return providerId === "serpbase" && options.mode === "maps"
+    ? "coffee near Brandenburg Gate Berlin"
+    : "Node.js AbortSignal documentation";
+}
+
 export function selectLiveTests(
   providers,
   providerId,

--- a/scripts/live-smoke.mjs
+++ b/scripts/live-smoke.mjs
@@ -2,7 +2,7 @@
 
 import { parseArgs } from "node:util";
 import { CAPABILITIES, createWebfox } from "../dist/index.js";
-import { selectLiveTests } from "./live-selection.mjs";
+import { liveSearchQuery, selectLiveTests } from "./live-selection.mjs";
 
 const controller = new AbortController();
 const cancel = () => controller.abort();
@@ -72,7 +72,7 @@ try {
           capability === "search"
             ? await client.search({
                 ...controls,
-                queries: ["Node.js AbortSignal documentation"],
+                queries: [liveSearchQuery(provider.id, options)],
                 maxResults: 3,
               })
             : capability === "contents"

--- a/src/application-types.ts
+++ b/src/application-types.ts
@@ -30,6 +30,7 @@ export interface CapabilityInspection {
   provider?: ProviderId;
   configured: boolean;
   optionSchema?: Record<string, unknown>;
+  promptGuidelines?: readonly string[];
   defaults: { maxResults?: number; options: Record<string, unknown> };
 }
 export interface WebfoxClient {

--- a/src/application.ts
+++ b/src/application.ts
@@ -190,6 +190,13 @@ export function createWebfox(options: CreateWebfoxOptions = {}): WebfoxClient {
         capability,
         provider: selected,
         configured: configured(definition, capability),
+        ...(definition.capabilities[capability]?.promptGuidelines
+          ? {
+              promptGuidelines: [
+                ...definition.capabilities[capability]!.promptGuidelines!,
+              ],
+            }
+          : {}),
         // Static provider schemas contain no credentials. Redacting property
         // names such as maximum_number_of_tokens would invalidate the schema.
         optionSchema: optionSchema(

--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -28,6 +28,7 @@
                 "openai",
                 "parallel",
                 "perplexity",
+                "serpbase",
                 "serper",
                 "tavily",
                 "valyu",
@@ -3288,6 +3289,95 @@
                     }
                   },
                   "description": "Perplexity grounded generation options.",
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        },
+        "serpbase": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "credentials": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "api": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": ["env"]
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "value": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "required": ["value"]
+                    },
+                    {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "command": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string",
+                            "minLength": 1
+                          }
+                        }
+                      },
+                      "required": ["command"]
+                    }
+                  ]
+                }
+              }
+            },
+            "baseUrl": {
+              "type": "string",
+              "minLength": 1
+            },
+            "options": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "search": {
+                  "type": "object",
+                  "properties": {
+                    "hl": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "Google results language code (for example 'en')."
+                    },
+                    "gl": {
+                      "type": "string",
+                      "minLength": 1,
+                      "description": "Google results country code (for example 'us')."
+                    },
+                    "page": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "description": "1-based Google results page. Only this page is fetched; maxResults limits the returned results, not the upstream page size."
+                    },
+                    "device": {
+                      "enum": ["default", "pc", "mobile"],
+                      "description": "Google Search device: 'default' for automatic routing, 'pc' for desktop, or 'mobile'."
+                    }
+                  },
+                  "description": "SerpBase Google organic search options.",
                   "additionalProperties": false
                 }
               }

--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -3357,6 +3357,18 @@
                 "search": {
                   "type": "object",
                   "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "search",
+                        "images",
+                        "news",
+                        "videos",
+                        "maps",
+                        "maps-detail"
+                      ],
+                      "description": "Google endpoint: 'search' (default) for organic results, 'images' for visual references, 'news' for journalism, 'videos' for clips/tutorials, 'maps' for businesses/places, or 'maps-detail' for place enrichment. In maps-detail, each queries entry must be a feature_id returned by maps (0x...:0x...), not search text."
+                    },
                     "hl": {
                       "type": "string",
                       "minLength": 1,
@@ -3370,14 +3382,108 @@
                     "page": {
                       "type": "integer",
                       "minimum": 1,
-                      "description": "1-based Google results page. Only this page is fetched; maxResults limits the returned results, not the upstream page size."
+                      "description": "1-based results page (default 1). Not accepted in maps-detail. Only this page is fetched; maxResults limits the returned results, not the upstream page size."
                     },
                     "device": {
+                      "type": "string",
                       "enum": ["default", "pc", "mobile"],
-                      "description": "Google Search device: 'default' for automatic routing, 'pc' for desktop, or 'mobile'."
+                      "description": "Only for search mode: 'default' (default) for automatic routing, 'pc' for desktop, or 'mobile'."
+                    },
+                    "lat": {
+                      "type": "number",
+                      "minimum": -90,
+                      "maximum": 90,
+                      "description": "Maps mode only: map center latitude. Requires lng."
+                    },
+                    "lng": {
+                      "type": "number",
+                      "minimum": -180,
+                      "maximum": 180,
+                      "description": "Maps mode only: map center longitude. Requires lat."
+                    },
+                    "zoom": {
+                      "type": "integer",
+                      "minimum": 1,
+                      "maximum": 21,
+                      "description": "Maps mode only: zoom level, 1–21. Requires lat and lng; defaults to 14 when coordinates are supplied."
                     }
                   },
-                  "description": "SerpBase Google organic search options.",
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "mode": {
+                          "enum": ["search"]
+                        },
+                        "lat": false,
+                        "lng": false,
+                        "zoom": false
+                      }
+                    },
+                    {
+                      "properties": {
+                        "mode": {
+                          "enum": ["images"]
+                        },
+                        "device": false,
+                        "lat": false,
+                        "lng": false,
+                        "zoom": false
+                      }
+                    },
+                    {
+                      "properties": {
+                        "mode": {
+                          "enum": ["news"]
+                        },
+                        "device": false,
+                        "lat": false,
+                        "lng": false,
+                        "zoom": false
+                      }
+                    },
+                    {
+                      "properties": {
+                        "mode": {
+                          "enum": ["videos"]
+                        },
+                        "device": false,
+                        "lat": false,
+                        "lng": false,
+                        "zoom": false
+                      }
+                    },
+                    {
+                      "properties": {
+                        "mode": {
+                          "enum": ["maps"]
+                        },
+                        "device": false
+                      },
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "lat": false,
+                            "lng": false,
+                            "zoom": false
+                          }
+                        },
+                        {}
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "mode": {
+                          "enum": ["maps-detail"]
+                        },
+                        "page": false,
+                        "device": false,
+                        "lat": false,
+                        "lng": false,
+                        "zoom": false
+                      }
+                    }
+                  ],
+                  "description": "SerpBase Google search modes. In maps-detail, queries contains feature IDs instead of search text. Unknown or mode-incompatible options are rejected. Changing mode drops incompatible inherited defaults, not explicitly supplied options.",
                   "additionalProperties": false
                 }
               }

--- a/src/configuration/planning.ts
+++ b/src/configuration/planning.ts
@@ -60,8 +60,28 @@ export function effectiveOptions(
   options: Record<string, unknown> = {},
   mode: "request" | "defaults" = "request",
 ): Record<string, unknown> {
-  const result = deepMerge(
-    deepMerge(
+  const modes = definition.capabilities[capability]?.modeOptionKeys;
+  const merge = (
+    base: Record<string, unknown>,
+    override: Record<string, unknown>,
+  ) => {
+    const inherited = { ...base };
+    if (
+      modes &&
+      typeof override.mode === "string" &&
+      override.mode !== base.mode &&
+      Object.hasOwn(modes, override.mode)
+    ) {
+      const allowed = modes[override.mode];
+      for (const key of new Set(Object.values(modes).flat())) {
+        if (!allowed.includes(key)) delete inherited[key];
+      }
+    }
+    // Explicit invalid overrides remain present for validation, never silently dropped.
+    return deepMerge(inherited, override);
+  };
+  const result = merge(
+    merge(
       definition.defaults[capability] ?? {},
       config.providers?.[definition.id]?.options?.[capability] ?? {},
     ),

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -17,6 +17,7 @@ export const PROVIDER_IDS = [
   "openai",
   "parallel",
   "perplexity",
+  "serpbase",
   "serper",
   "tavily",
   "valyu",

--- a/src/pi.ts
+++ b/src/pi.ts
@@ -93,7 +93,12 @@ export default function webExtension(pi: ExtensionAPI): void {
     pi.registerTool({
       name: `web_${capability}`,
       label: `Web ${capability[0].toUpperCase()}${capability.slice(1)}`,
-      description: `${descriptions[capability]} Output is truncated to 2000 lines or 50 KiB; full results are saved to a file when truncated.`,
+      // Keep provider guidance with the tool schema, including with custom system prompts.
+      description: [
+        descriptions[capability],
+        ...(inspection.promptGuidelines ?? []),
+        "Output is truncated to 2000 lines or 50 KiB; full results are saved to a file when truncated.",
+      ].join("\n"),
       parameters,
       prepareArguments(args) {
         // Pi still validates and coerces the returned arguments before execute.

--- a/src/providers/contract.ts
+++ b/src/providers/contract.ts
@@ -102,6 +102,7 @@ export interface ProviderConfigMap {
   openai: import("./openai/types.js").OpenAI;
   parallel: import("./parallel/types.js").Parallel;
   perplexity: import("./perplexity/types.js").Perplexity;
+  serpbase: import("./serpbase/types.js").SerpBase;
   serper: import("./serper/types.js").Serper;
   tavily: import("./tavily/types.js").Tavily;
   valyu: import("./valyu/types.js").Valyu;

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -12,6 +12,8 @@ import type {
 
 import type { ProviderCredentialMetadata } from "./metadata.js";
 export interface CapabilityDefinition {
+  /** Overall deadline when neither the request nor execution configuration sets one. */
+  defaultTimeoutMs?: number;
   options?: Record<string, unknown>;
   limits?: { maxResults?: number };
   promptGuidelines?: readonly string[];

--- a/src/providers/definition.ts
+++ b/src/providers/definition.ts
@@ -15,6 +15,8 @@ export interface CapabilityDefinition {
   options?: Record<string, unknown>;
   limits?: { maxResults?: number };
   promptGuidelines?: readonly string[];
+  /** Allowed option keys per mode; switching modes drops incompatible inherited defaults. */
+  modeOptionKeys?: Readonly<Record<string, readonly string[]>>;
   /** Whether the entire operation may be repeated after a transient failure. */
   retrySafe: boolean;
 }

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -9,6 +9,7 @@ import { ollamaProvider } from "./ollama/definition.js";
 import { openaiProvider } from "./openai/definition.js";
 import { parallelProvider } from "./parallel/definition.js";
 import { perplexityProvider } from "./perplexity/definition.js";
+import { serpbaseProvider } from "./serpbase/definition.js";
 import { serperProvider } from "./serper/definition.js";
 import { tavilyProvider } from "./tavily/definition.js";
 import { valyuProvider } from "./valyu/definition.js";
@@ -26,6 +27,7 @@ export const providers = {
   openai: openaiProvider,
   parallel: parallelProvider,
   perplexity: perplexityProvider,
+  serpbase: serpbaseProvider,
   serper: serperProvider,
   tavily: tavilyProvider,
   valyu: valyuProvider,

--- a/src/providers/serpbase/adapter.ts
+++ b/src/providers/serpbase/adapter.ts
@@ -1,4 +1,5 @@
 import { httpError, WebfoxError } from "../../errors.js";
+import { validateOptions } from "../../configuration/planning.js";
 import type {
   ProviderContext,
   ProviderRequest,
@@ -6,11 +7,13 @@ import type {
   SearchResult,
 } from "../contract.js";
 import { trimSnippet } from "../shared.js";
-import type { SerpBase } from "./types.js";
+import { serpbaseProvider } from "./definition.js";
+import { SERPBASE_MODES, type SerpBase, type SerpBaseMode } from "./types.js";
 
 const DEFAULT_BASE_URL = "https://api.serpbase.dev";
 // Business status codes are independent of the HTTP status, including HTTP 200.
 const RETRYABLE_STATUSES = new Set([1029, 1500, 1502, 1503, 1504]);
+const FEATURE_ID = /^0x[0-9a-f]+:0x[0-9a-f]+$/i;
 
 export const adapter = {
   async search(
@@ -18,19 +21,33 @@ export const adapter = {
     config: SerpBase,
     context: ProviderContext,
   ): Promise<SearchResponse> {
+    const options: Record<string, unknown> = {
+      ...request.options,
+      mode: request.options?.mode ?? "search",
+    };
+    validateOptions(serpbaseProvider, "search", options);
+    const mode = options.mode as SerpBaseMode;
+    const endpoint = SERPBASE_MODES[mode];
+    if (mode === "maps-detail" && !FEATURE_ID.test(request.query)) {
+      throw new WebfoxError(
+        "INVALID_INPUT",
+        "SerpBase maps-detail requires a feature_id (0x...:0x...) in each queries entry. First use mode maps and copy the returned feature_id; names, place_id, CID, and Maps URLs are not accepted.",
+      );
+    }
     const apiKey = config.credentials?.api;
     if (!apiKey) throw new Error("SerpBase search is missing an API key");
 
-    const options = request.options ?? {};
     const response = await fetch(
-      `${(config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "")}/google/search`,
+      `${(config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "")}/google/${endpoint.path}`,
       {
         method: "POST",
         headers: { "content-type": "application/json", "X-API-Key": apiKey },
         body: JSON.stringify({
-          q: request.query,
+          ...(mode === "maps-detail"
+            ? { feature_id: request.query }
+            : { q: request.query }),
           ...Object.fromEntries(
-            ["hl", "gl", "page", "device"].flatMap((key) =>
+            endpoint.options.flatMap((key) =>
               options[key] === undefined ? [] : [[key, options[key]]],
             ),
           ),
@@ -51,7 +68,7 @@ export const adapter = {
     const apiFailure = typeof status === "number" && status !== 0;
     if (!response.ok || apiFailure) {
       const detail = (text(payload?.error) ?? body.trim()).slice(0, 500);
-      const message = `SerpBase search request failed (HTTP ${response.status}${apiFailure ? `, status ${status}` : ""})${detail ? `: ${detail}` : "."}`;
+      const message = `SerpBase ${mode} request failed (HTTP ${response.status}${apiFailure ? `, status ${status}` : ""})${detail ? `: ${detail}` : "."}`;
       if (apiFailure) {
         throw new WebfoxError("PROVIDER_FAILURE", message, {
           retryable: RETRYABLE_STATUSES.has(status),
@@ -59,25 +76,38 @@ export const adapter = {
       }
       throw httpError(response, message);
     }
+    const collection = payload?.[endpoint.result];
     if (
       !payload ||
       status !== 0 ||
-      (payload.organic !== undefined && !Array.isArray(payload.organic))
+      (collection !== undefined &&
+        (mode === "maps-detail"
+          ? !asRecord(collection)
+          : !Array.isArray(collection)))
     ) {
       throw new WebfoxError(
         "PROVIDER_FAILURE",
-        "SerpBase returned an invalid search response.",
+        `SerpBase returned an invalid ${mode} response.`,
         { retryable: false },
       );
     }
 
-    const { organic, ...searchContext } = payload;
-    const results = (Array.isArray(organic) ? organic : [])
-      .map((entry) => toSearchResult(entry, searchContext))
+    const searchContext = { ...payload };
+    // Keep rich SERP modules, but don't repeat result collections on every row.
+    for (const { result } of Object.values(SERPBASE_MODES))
+      delete searchContext[result];
+    const entries =
+      mode === "maps-detail"
+        ? collection === undefined
+          ? []
+          : [collection]
+        : ((collection as unknown[] | undefined) ?? []);
+    const results = entries
+      .map((entry) => toSearchResult(entry, searchContext, mode))
       .filter((result): result is SearchResult => result !== undefined);
     return {
       provider: "serpbase",
-      // No upstream count parameter or automatic pagination: one requested page.
+      // No upstream count parameter or automatic pagination: one page or place.
       results: results.slice(
         0,
         Math.max(1, Math.trunc(request.maxResults || 0)),
@@ -89,18 +119,127 @@ export const adapter = {
 function toSearchResult(
   entry: unknown,
   searchContext: Record<string, unknown>,
+  mode: SerpBaseMode,
 ): SearchResult | undefined {
   const record = asRecord(entry);
-  if (!record) return undefined;
-  const url = text(record.link) ?? text(record.url);
+  if (!record || (mode === "images" && isNavigationImage(record)))
+    return undefined;
+  const isPlace = mode === "maps" || mode === "maps-detail";
+  const featureId = text(record.feature_id);
+  const url = isPlace
+    ? (text(record.google_maps_url) ??
+      text(record.url) ??
+      text(record.website) ??
+      (featureId && FEATURE_ID.test(featureId)
+        ? `https://www.google.com/maps?ftid=${encodeURIComponent(featureId)}`
+        : undefined))
+    : (text(record.link) ??
+      text(record.url) ??
+      (mode === "images" ? text(record.image_url) : undefined));
   if (!url) return undefined;
   const { title, link: _link, url: _url, snippet, ...metadata } = record;
   return {
-    title: text(title) ?? url,
+    title: text(title) ?? text(record.name) ?? url,
     url,
-    snippet: trimSnippet(text(snippet)),
-    metadata: { ...metadata, searchContext },
+    snippet: resultSnippet(record, mode),
+    metadata: { ...metadata, mode, searchContext },
   };
+}
+
+/** Include actionable fields in the existing snippet surface, not UI-only metadata.
+ * CLI text, model content, and the plain-text Pi renderer then agree without a new tool. */
+function resultSnippet(
+  record: Record<string, unknown>,
+  mode: SerpBaseMode,
+): string {
+  const lines: string[] = [];
+  const excerpt =
+    text(record.snippet) ??
+    text(record.short_description) ??
+    text(record.description);
+  // Some video responses contain empty layout labels rather than an excerpt.
+  if (
+    excerpt &&
+    !(mode === "videos" && /^\s*Duration:\s*Posted:\s*$/i.test(excerpt))
+  )
+    lines.push(trimSnippet(excerpt));
+  const add = (label: string, value: unknown, limit = 600) => {
+    if (typeof value === "number" && Number.isFinite(value))
+      value = String(value);
+    if (text(value))
+      lines.push(`${label}: ${trimSnippet(value as string, limit)}`);
+  };
+  const json = (label: string, value: unknown) => {
+    if (value && typeof value === "object")
+      add(label, JSON.stringify(value), 1200);
+  };
+  if (mode === "images") {
+    // Keep URLs intact so the model can fetch the actual image or its source page.
+    add("Image URL", record.image_url, Infinity);
+    add("Source page", text(record.link) ?? text(record.url), Infinity);
+    add(
+      "Thumbnail",
+      text(record.thumbnail_url) ?? text(record.thumbnail),
+      Infinity,
+    );
+    add("Source", text(record.source) ?? text(record.domain));
+  } else if (mode === "news" || mode === "videos") {
+    add("Source", record.source);
+    const published = text(record.published_at) ?? text(record.time);
+    // Observed video payloads sometimes put durations in both time aliases.
+    // Preserve the value without claiming it is a publication date or duration.
+    add(
+      published && /^\d{1,3}:\d{2}(?::\d{2})?$/.test(published.trim())
+        ? "Time (upstream)"
+        : "Published",
+      published,
+    );
+    if (mode === "videos") add("Duration", record.duration);
+    add(
+      "Thumbnail",
+      text(record.thumbnail_url) ?? text(record.thumbnail),
+      Infinity,
+    );
+  } else if (mode === "maps" || mode === "maps-detail") {
+    add("feature_id", record.feature_id, Infinity);
+    add("Address", record.address);
+    add("Rating", record.rating);
+    add("Reviews", record.review_count);
+    add("Phone", text(record.phone_international) ?? text(record.phone));
+    add("Website", record.website, Infinity);
+    if (
+      typeof record.latitude === "number" &&
+      typeof record.longitude === "number"
+    )
+      add("Coordinates", `${record.latitude}, ${record.longitude}`);
+    if (Array.isArray(record.types))
+      add(
+        "Categories",
+        record.types.filter((item) => typeof item === "string").join(", "),
+      );
+    json("Hours", record.hours);
+    json("Open status", record.open_status);
+    if (mode === "maps-detail") json("Attributes", record.attributes);
+  }
+  return lines.join("\n");
+}
+
+// Discard only the observed Google navigation-logo artifact, not Google-hosted
+// content generally. Filtering happens before the local result limit.
+function isNavigationImage(record: Record<string, unknown>): boolean {
+  try {
+    const image = new URL(String(record.image_url));
+    const source = new URL(String(record.link ?? record.url));
+    return (
+      image.hostname === "www.gstatic.com" &&
+      image.pathname === "/m/images/icons/googleg.gif" &&
+      (source.hostname === "www.google.com" ||
+        source.hostname === "google.com") &&
+      (source.pathname === "/" || source.pathname === "/search")
+    );
+  } catch {
+    return false;
+  }
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/src/providers/serpbase/adapter.ts
+++ b/src/providers/serpbase/adapter.ts
@@ -1,0 +1,114 @@
+import { httpError, WebfoxError } from "../../errors.js";
+import type {
+  ProviderContext,
+  ProviderRequest,
+  SearchResponse,
+  SearchResult,
+} from "../contract.js";
+import { trimSnippet } from "../shared.js";
+import type { SerpBase } from "./types.js";
+
+const DEFAULT_BASE_URL = "https://api.serpbase.dev";
+// Business status codes are independent of the HTTP status, including HTTP 200.
+const RETRYABLE_STATUSES = new Set([1029, 1500, 1502, 1503, 1504]);
+
+export const adapter = {
+  async search(
+    request: ProviderRequest<"search">,
+    config: SerpBase,
+    context: ProviderContext,
+  ): Promise<SearchResponse> {
+    const apiKey = config.credentials?.api;
+    if (!apiKey) throw new Error("SerpBase search is missing an API key");
+
+    const options = request.options ?? {};
+    const response = await fetch(
+      `${(config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, "")}/google/search`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", "X-API-Key": apiKey },
+        body: JSON.stringify({
+          q: request.query,
+          ...Object.fromEntries(
+            ["hl", "gl", "page", "device"].flatMap((key) =>
+              options[key] === undefined ? [] : [[key, options[key]]],
+            ),
+          ),
+        }),
+        signal: context.signal,
+      },
+    );
+
+    // Read once so HTTP errors retain their classification even for non-JSON bodies.
+    const body = await response.text();
+    let payload: Record<string, unknown> | undefined;
+    try {
+      payload = asRecord(JSON.parse(body));
+    } catch {
+      // Handled below, after checking the HTTP and business statuses.
+    }
+    const status = payload?.status;
+    const apiFailure = typeof status === "number" && status !== 0;
+    if (!response.ok || apiFailure) {
+      const detail = (text(payload?.error) ?? body.trim()).slice(0, 500);
+      const message = `SerpBase search request failed (HTTP ${response.status}${apiFailure ? `, status ${status}` : ""})${detail ? `: ${detail}` : "."}`;
+      if (apiFailure) {
+        throw new WebfoxError("PROVIDER_FAILURE", message, {
+          retryable: RETRYABLE_STATUSES.has(status),
+        });
+      }
+      throw httpError(response, message);
+    }
+    if (
+      !payload ||
+      status !== 0 ||
+      (payload.organic !== undefined && !Array.isArray(payload.organic))
+    ) {
+      throw new WebfoxError(
+        "PROVIDER_FAILURE",
+        "SerpBase returned an invalid search response.",
+        { retryable: false },
+      );
+    }
+
+    const { organic, ...searchContext } = payload;
+    const results = (Array.isArray(organic) ? organic : [])
+      .map((entry) => toSearchResult(entry, searchContext))
+      .filter((result): result is SearchResult => result !== undefined);
+    return {
+      provider: "serpbase",
+      // No upstream count parameter or automatic pagination: one requested page.
+      results: results.slice(
+        0,
+        Math.max(1, Math.trunc(request.maxResults || 0)),
+      ),
+    };
+  },
+};
+
+function toSearchResult(
+  entry: unknown,
+  searchContext: Record<string, unknown>,
+): SearchResult | undefined {
+  const record = asRecord(entry);
+  if (!record) return undefined;
+  const url = text(record.link) ?? text(record.url);
+  if (!url) return undefined;
+  const { title, link: _link, url: _url, snippet, ...metadata } = record;
+  return {
+    title: text(title) ?? url,
+    url,
+    snippet: trimSnippet(text(snippet)),
+    metadata: { ...metadata, searchContext },
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function text(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}

--- a/src/providers/serpbase/definition.ts
+++ b/src/providers/serpbase/definition.ts
@@ -1,4 +1,5 @@
 import { defineProvider } from "../definition.js";
+import { SERPBASE_MODES } from "./types.js";
 
 export const serpbaseProvider = defineProvider({
   id: "serpbase",
@@ -8,14 +9,26 @@ export const serpbaseProvider = defineProvider({
   credentials: [{ name: "api", environmentVariable: "SERPBASE_API_KEY" }],
   fields: ["credentials", "baseUrl", "options"],
   defaults: {
-    search: { hl: "en", gl: "us", page: 1, device: "default" },
+    search: { mode: "search", hl: "en", gl: "us", page: 1, device: "default" },
   },
   credentialDefaults: {},
   capabilities: {
     search: {
+      modeOptionKeys: Object.fromEntries(
+        Object.entries(SERPBASE_MODES).map(([mode, definition]) => [
+          mode,
+          definition.options,
+        ]),
+      ),
       options: {
         type: "object",
         properties: {
+          mode: {
+            type: "string",
+            enum: Object.keys(SERPBASE_MODES),
+            description:
+              "Google endpoint: 'search' (default) for organic results, 'images' for visual references, 'news' for journalism, 'videos' for clips/tutorials, 'maps' for businesses/places, or 'maps-detail' for place enrichment. In maps-detail, each queries entry must be a feature_id returned by maps (0x...:0x...), not search text.",
+          },
           hl: {
             type: "string",
             minLength: 1,
@@ -30,16 +43,67 @@ export const serpbaseProvider = defineProvider({
             type: "integer",
             minimum: 1,
             description:
-              "1-based Google results page. Only this page is fetched; maxResults limits the returned results, not the upstream page size.",
+              "1-based results page (default 1). Not accepted in maps-detail. Only this page is fetched; maxResults limits the returned results, not the upstream page size.",
           },
           device: {
+            type: "string",
             enum: ["default", "pc", "mobile"],
             description:
-              "Google Search device: 'default' for automatic routing, 'pc' for desktop, or 'mobile'.",
+              "Only for search mode: 'default' (default) for automatic routing, 'pc' for desktop, or 'mobile'.",
+          },
+          lat: {
+            type: "number",
+            minimum: -90,
+            maximum: 90,
+            description: "Maps mode only: map center latitude. Requires lng.",
+          },
+          lng: {
+            type: "number",
+            minimum: -180,
+            maximum: 180,
+            description: "Maps mode only: map center longitude. Requires lat.",
+          },
+          zoom: {
+            type: "integer",
+            minimum: 1,
+            maximum: 21,
+            description:
+              "Maps mode only: zoom level, 1–21. Requires lat and lng; defaults to 14 when coordinates are supplied.",
           },
         },
-        description: "SerpBase Google organic search options.",
+        // Flat properties keep CLI flags discoverable. Each branch prohibits
+        // fields for other modes; missing discriminators allow partial overrides.
+        anyOf: Object.entries(SERPBASE_MODES).map(([mode, definition]) => ({
+          properties: {
+            mode: { enum: [mode] },
+            ...Object.fromEntries(
+              ["page", "device", "lat", "lng", "zoom"]
+                .filter(
+                  (key) =>
+                    !(definition.options as readonly string[]).includes(key),
+                )
+                .map((key) => [key, false]),
+            ),
+          },
+          ...(mode === "maps"
+            ? {
+                anyOf: [
+                  { properties: { lat: false, lng: false, zoom: false } },
+                  { required: ["lat", "lng"] },
+                ],
+              }
+            : {}),
+        })),
+        description:
+          "SerpBase Google search modes. In maps-detail, queries contains feature IDs instead of search text. Unknown or mode-incompatible options are rejected. Changing mode drops incompatible inherited defaults, not explicitly supplied options.",
       },
+      promptGuidelines: [
+        "Use options.mode to choose SerpBase search (organic), images (visual references), news (journalism), videos (clips/tutorials), or maps (businesses/places).",
+        "To enrich a place, first use mode maps, then call the same web_search tool with mode maps-detail and the returned feature_id strings in queries. Do not substitute names, place_id, CID, or Maps URLs for feature_id.",
+        "Use lat and lng together to center a maps search; zoom requires both. Device selection applies only to organic search, and maps-detail accepts only hl and gl alongside mode.",
+        "Each query fetches one page or one place. maxResults only trims locally; request additional pages explicitly. Requests, including retries, may incur charges.",
+        "Image results include image and source-page URLs, not image contents. News/video times are upstream text, not verified timestamps. Maps hours and contact fields are shown only when returned.",
+      ],
       retrySafe: true,
     },
   },

--- a/src/providers/serpbase/definition.ts
+++ b/src/providers/serpbase/definition.ts
@@ -14,6 +14,7 @@ export const serpbaseProvider = defineProvider({
   credentialDefaults: {},
   capabilities: {
     search: {
+      defaultTimeoutMs: 120_000,
       modeOptionKeys: Object.fromEntries(
         Object.entries(SERPBASE_MODES).map(([mode, definition]) => [
           mode,

--- a/src/providers/serpbase/definition.ts
+++ b/src/providers/serpbase/definition.ts
@@ -1,0 +1,47 @@
+import { defineProvider } from "../definition.js";
+
+export const serpbaseProvider = defineProvider({
+  id: "serpbase",
+  label: "SerpBase",
+  docsUrl: "https://serpbase.dev/docs",
+  local: false,
+  credentials: [{ name: "api", environmentVariable: "SERPBASE_API_KEY" }],
+  fields: ["credentials", "baseUrl", "options"],
+  defaults: {
+    search: { hl: "en", gl: "us", page: 1, device: "default" },
+  },
+  credentialDefaults: {},
+  capabilities: {
+    search: {
+      options: {
+        type: "object",
+        properties: {
+          hl: {
+            type: "string",
+            minLength: 1,
+            description: "Google results language code (for example 'en').",
+          },
+          gl: {
+            type: "string",
+            minLength: 1,
+            description: "Google results country code (for example 'us').",
+          },
+          page: {
+            type: "integer",
+            minimum: 1,
+            description:
+              "1-based Google results page. Only this page is fetched; maxResults limits the returned results, not the upstream page size.",
+          },
+          device: {
+            enum: ["default", "pc", "mobile"],
+            description:
+              "Google Search device: 'default' for automatic routing, 'pc' for desktop, or 'mobile'.",
+          },
+        },
+        description: "SerpBase Google organic search options.",
+      },
+      retrySafe: true,
+    },
+  },
+  load: async () => (await import("./adapter.js")).adapter,
+});

--- a/src/providers/serpbase/types.ts
+++ b/src/providers/serpbase/types.ts
@@ -1,5 +1,28 @@
 import type { Provider } from "../contract.js";
 
+export const SERPBASE_MODES = {
+  search: {
+    path: "search",
+    result: "organic",
+    options: ["hl", "gl", "page", "device"],
+  },
+  images: { path: "images", result: "images", options: ["hl", "gl", "page"] },
+  news: { path: "news", result: "news", options: ["hl", "gl", "page"] },
+  videos: { path: "videos", result: "videos", options: ["hl", "gl", "page"] },
+  maps: {
+    path: "maps/search",
+    result: "places",
+    options: ["hl", "gl", "page", "lat", "lng", "zoom"],
+  },
+  "maps-detail": {
+    path: "maps/detail",
+    result: "place",
+    options: ["hl", "gl"],
+  },
+} as const;
+
+export type SerpBaseMode = keyof typeof SERPBASE_MODES;
+
 export interface SerpBase extends Provider {
   baseUrl?: string;
 }

--- a/src/providers/serpbase/types.ts
+++ b/src/providers/serpbase/types.ts
@@ -1,0 +1,5 @@
+import type { Provider } from "../contract.js";
+
+export interface SerpBase extends Provider {
+  baseUrl?: string;
+}

--- a/src/render.ts
+++ b/src/render.ts
@@ -21,7 +21,7 @@ export function renderTextDocument(
           ? entry.value.results
               .map(
                 (result, i) =>
-                  `${i + 1}. ${result.title}\n   ${result.url}\n   ${result.snippet}`,
+                  `${i + 1}. ${result.title}\n   ${result.url}\n   ${result.snippet.replaceAll("\n", "\n   ")}`,
               )
               .join("\n\n")
           : "No results found.";

--- a/src/runtime/execute.ts
+++ b/src/runtime/execute.ts
@@ -50,8 +50,10 @@ export class ExecutionRuntime {
     const timeoutMs =
       request.timeoutMs ??
       (capability === "research"
-        ? (plan.policy.researchTimeoutMs ?? 1_800_000)
-        : (plan.policy.timeoutMs ?? 30_000));
+        ? plan.policy.researchTimeoutMs
+        : plan.policy.timeoutMs) ??
+      definition.capabilities[capability]?.defaultTimeoutMs ??
+      (capability === "research" ? 1_800_000 : 30_000);
     if (
       !Number.isSafeInteger(timeoutMs) ||
       timeoutMs <= 0 ||

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -59,6 +59,89 @@ async function cli(
   return { code, stdout, stderr };
 }
 describe("CLI contracts", () => {
+  it("configures SerpBase as the default and exposes native search flags", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "webfox-serpbase-"));
+    directories.push(cwd);
+    const config = join(cwd, "config.yaml");
+    await writeFile(
+      config,
+      stringify({
+        providers: {
+          serpbase: { credentials: { api: { value: "cli-test-key" } } },
+        },
+      }),
+    );
+    const saved = await cli([
+      "config",
+      "default",
+      "search",
+      "serpbase",
+      "--config",
+      config,
+    ]);
+    expect(saved.code).toBe(0);
+    const fetch = vi.fn().mockResolvedValue(
+      Response.json({
+        status: 0,
+        page: 2,
+        organic: [
+          {
+            title: "Example",
+            link: "https://example.com",
+            snippet: "A passage",
+            rank: 1,
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetch);
+    const result = await cli([
+      "search",
+      "site:example.com",
+      "--config",
+      config,
+      "--hl",
+      "de",
+      "--gl",
+      "de",
+      "--page",
+      "2",
+      "--device",
+      "pc",
+      "--format",
+      "json",
+    ]);
+    expect(result.code).toBe(0);
+    expect(JSON.parse(fetch.mock.calls[0][1].body)).toEqual({
+      q: "site:example.com",
+      hl: "de",
+      gl: "de",
+      page: 2,
+      device: "pc",
+    });
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      provider: "serpbase",
+      status: "ok",
+      results: [
+        {
+          ok: true,
+          value: {
+            results: [
+              {
+                url: "https://example.com",
+                metadata: { rank: 1, searchContext: { page: 2 } },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    const help = await cli(["search", "--provider", "serpbase", "--help"]);
+    expect(help.code).toBe(0);
+    for (const flag of ["--hl", "--gl", "--page", "--device"])
+      expect(help.stdout).toContain(flag);
+    expect(help.stdout).not.toContain("--mode");
+  });
   it("exposes You.com native flags and forwards them through the public client", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "webfox-youcom-"));
     directories.push(cwd);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -138,9 +138,59 @@ describe("CLI contracts", () => {
     });
     const help = await cli(["search", "--provider", "serpbase", "--help"]);
     expect(help.code).toBe(0);
-    for (const flag of ["--hl", "--gl", "--page", "--device"])
+    for (const flag of [
+      "--hl",
+      "--gl",
+      "--page",
+      "--device",
+      "--mode",
+      "--lat",
+      "--lng",
+      "--zoom",
+    ])
       expect(help.stdout).toContain(flag);
-    expect(help.stdout).not.toContain("--mode");
+    expect(help.stdout).toContain("maps-detail");
+
+    fetch.mockResolvedValue(
+      Response.json({
+        status: 0,
+        place: {
+          name: "Cafe",
+          feature_id: "0x123:0x456",
+          address: "Main Street",
+          rating: 4.5,
+        },
+      }),
+    );
+    const detail = await cli([
+      "search",
+      "0x123:0x456",
+      "--config",
+      config,
+      "--mode",
+      "maps-detail",
+    ]);
+    expect(detail.code).toBe(0);
+    expect(JSON.parse(fetch.mock.lastCall![1].body)).toEqual({
+      feature_id: "0x123:0x456",
+      hl: "en",
+      gl: "us",
+    });
+    expect(detail.stdout).toContain("feature_id: 0x123:0x456");
+    expect(detail.stdout).toContain("Address: Main Street");
+    expect(detail.stdout).toContain("Rating: 4.5");
+    const invalid = await cli([
+      "search",
+      "coffee",
+      "--config",
+      config,
+      "--mode",
+      "maps",
+      "--lat",
+      "52.5",
+    ]);
+    expect(invalid.code).not.toBe(0);
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
   it("exposes You.com native flags and forwards them through the public client", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "webfox-youcom-"));

--- a/test/live-selection.test.ts
+++ b/test/live-selection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 // @ts-expect-error The smoke-test helper runs directly in Node.js.
-import { selectLiveTests } from "../scripts/live-selection.mjs";
+import * as smoke from "../scripts/live-selection.mjs";
+const { liveSearchQuery, selectLiveTests } = smoke;
 
 const providers = [
   {
@@ -12,6 +13,15 @@ const providers = [
 ];
 
 describe("live smoke selection", () => {
+  it("uses a place query for SerpBase Maps without changing other smoke inputs", () => {
+    expect(liveSearchQuery("serpbase", { mode: "maps" })).toBe(
+      "coffee near Brandenburg Gate Berlin",
+    );
+    expect(liveSearchQuery("serpbase", { mode: "search" })).toBe(
+      "Node.js AbortSignal documentation",
+    );
+    expect(liveSearchQuery("exa")).toBe("Node.js AbortSignal documentation");
+  });
   it("selects every configured non-research capability", () => {
     const result = selectLiveTests(providers, "all", "all", false);
     expect(

--- a/test/pi-search-render.test.ts
+++ b/test/pi-search-render.test.ts
@@ -47,6 +47,19 @@ function document(): SearchDocument {
 }
 
 describe("plain-text search result rendering", () => {
+  it("indents every line of structured search snippets in text output", () => {
+    const doc = document();
+    const entry = doc.results[0];
+    if (!entry.ok) throw new Error("Expected successful fixture");
+    entry.value.results[0].snippet =
+      "feature_id: 0x123:0x456\nAddress: Main Street\nPhone: +49 123";
+    expect(renderTextDocument(doc)).toContain(
+      "\n   feature_id: 0x123:0x456\n   Address: Main Street\n   Phone: +49 123",
+    );
+    expect(entry.value.results[0].snippet).toBe(
+      "feature_id: 0x123:0x456\nAddress: Main Street\nPhone: +49 123",
+    );
+  });
   it("keeps source Markdown literal and leaves model-facing content unchanged", () => {
     const doc = document();
     const content = renderTextDocument(doc);

--- a/test/pi.test.ts
+++ b/test/pi.test.ts
@@ -6,6 +6,7 @@ import { visibleWidth } from "@earendil-works/pi-tui";
 import { afterEach, expect, it, vi } from "vitest";
 import webExtension from "../src/pi.js";
 import { customConfig } from "./helpers.js";
+import { Check } from "typebox/value";
 
 vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@earendil-works/pi-coding-agent")>()),
@@ -251,6 +252,121 @@ it.each([
     expect(registerTool.mock.calls[0][0].name).toBe("web_search");
   },
 );
+
+it("exposes every SerpBase mode through web_search and supports a model-visible Maps follow-up", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "webfox-pi-serpbase-"));
+  paths.push(directory);
+  const path = join(directory, "config.yaml");
+  await writeFile(
+    path,
+    stringify({
+      defaults: { search: { provider: "serpbase" } },
+      providers: { serpbase: { credentials: { api: { value: "test-key" } } } },
+    }),
+  );
+  vi.stubEnv("WEBFOX_CONFIG", path);
+  const tools: any[] = [];
+  webExtension({
+    registerTool: (tool: any) => tools.push(tool),
+    on() {},
+  } as any);
+  expect(tools.map((tool) => tool.name)).toEqual(["web_search"]);
+  const tool = tools[0];
+  expect(tool.parameters.properties.options.properties.mode.enum).toEqual([
+    "search",
+    "images",
+    "news",
+    "videos",
+    "maps",
+    "maps-detail",
+  ]);
+  expect(tool.description).toContain("feature_id strings in queries");
+  expect(tool.description).toContain(
+    "Image results include image and source-page URLs",
+  );
+  expect(tool.description).not.toContain("web_lookup");
+  expect(tool.description).not.toContain("Serper");
+  for (const mode of [
+    "search",
+    "images",
+    "news",
+    "videos",
+    "maps",
+    "maps-detail",
+  ]) {
+    expect(
+      Check(tool.parameters, { queries: ["input"], options: { mode } }),
+    ).toBe(true);
+  }
+  expect(
+    Check(tool.parameters, {
+      queries: ["input"],
+      options: { mode: "images", device: "pc" },
+    }),
+  ).toBe(false);
+  const id = "0x123:0x456";
+  const fetch = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValueOnce(
+      Response.json({
+        status: 0,
+        places: [{ name: "Cafe", feature_id: id, address: "Main Street" }],
+      }),
+    )
+    .mockResolvedValueOnce(
+      Response.json({
+        status: 0,
+        place: {
+          name: "Cafe",
+          feature_id: id,
+          website: "https://cafe.test",
+          phone: "+49 123",
+          hours: { Monday: "09:00–17:00" },
+        },
+      }),
+    );
+  const maps = await tool.execute(
+    "maps",
+    { queries: ["cafe"], options: { mode: "maps" } },
+    undefined,
+    undefined,
+    { cwd: directory },
+  );
+  // Follow the ID from model-visible content, never the UI-only details object.
+  const featureId = maps.content[0].text.match(
+    /feature_id: (0x[0-9a-f]+:0x[0-9a-f]+)/,
+  )?.[1];
+  expect(featureId).toBe(id);
+  const details = await tool.execute(
+    "detail",
+    { queries: [featureId], options: { mode: "maps-detail" } },
+    undefined,
+    undefined,
+    { cwd: directory },
+  );
+  expect(details.content[0].text).toContain("Phone: +49 123");
+  expect(details.content[0].text).toContain("Monday");
+  expect(details.content[0].text).toContain("https://cafe.test");
+  expect(JSON.parse(fetch.mock.calls[1][1]!.body as string)).toEqual({
+    feature_id: id,
+    hl: "en",
+    gl: "us",
+  });
+  expect(tools).toHaveLength(1);
+  const theme = {
+    fg: (_color: string, text: string) => text,
+    bold: (text: string) => text,
+    underline: (text: string) => text,
+  };
+  expect(
+    tool
+      .renderResult(details, { expanded: true, isPartial: false }, theme, {
+        isError: false,
+      })
+      .render(160)
+      .join("\n"),
+  ).toContain(`feature_id: ${id}`);
+});
 
 it("keeps unconfigured notifications generic", async () => {
   const directory = await mkdtemp(join(tmpdir(), "web-pi-"));

--- a/test/provider-option-contracts.test.ts
+++ b/test/provider-option-contracts.test.ts
@@ -120,6 +120,11 @@ const samples: Array<{
     },
   },
   {
+    provider: "serpbase",
+    capability: "search",
+    options: { hl: "en", gl: "us", page: 2, device: "mobile" },
+  },
+  {
     provider: "youcom",
     capability: "search",
     options: {

--- a/test/provider-sdk-wire.test.ts
+++ b/test/provider-sdk-wire.test.ts
@@ -41,43 +41,80 @@ function client(provider: ProviderId) {
   });
 }
 
-it("forwards SerpBase's native options to one Google search page", async () => {
-  response = {
-    status: 0,
-    organic: [
+it.each([
+  {
+    mode: "search",
+    path: "/google/search",
+    field: "organic",
+    extra: { page: 2, device: "mobile" },
+  },
+  {
+    mode: "images",
+    path: "/google/images",
+    field: "images",
+    extra: { page: 2 },
+  },
+  { mode: "news", path: "/google/news", field: "news", extra: { page: 2 } },
+  {
+    mode: "videos",
+    path: "/google/videos",
+    field: "videos",
+    extra: { page: 2 },
+  },
+  {
+    mode: "maps",
+    path: "/google/maps/search",
+    field: "places",
+    extra: { page: 2, lat: 52.5, lng: 13.4, zoom: 14 },
+  },
+  {
+    mode: "maps-detail",
+    path: "/google/maps/detail",
+    field: "place",
+    extra: {},
+  },
+])(
+  "forwards SerpBase $mode to $path without unrelated fields",
+  async ({ mode, path, field, extra }) => {
+    const row = {
+      title: "Example",
+      link: "https://example.com",
+      google_maps_url: "https://example.com",
+      snippet: "Result",
+      feature_id: "0x123:0x456",
+    };
+    response = { status: 0, [field]: mode === "maps-detail" ? row : [row] };
+    const options = { mode, hl: "de", gl: "de", ...extra };
+    const result = await client("serpbase").search({
+      provider: "serpbase",
+      queries: [mode === "maps-detail" ? row.feature_id : "q"],
+      maxResults: 3,
+      options,
+    });
+    expect(result.status).toBe("ok");
+    expect(requests).toEqual([
       {
-        rank: 1,
-        title: "Example",
-        link: "https://example.com",
-        snippet: "Result",
-      },
-    ],
-  };
-  const options = { hl: "de", gl: "de", page: 2, device: "mobile" };
-  const result = await client("serpbase").search({
-    provider: "serpbase",
-    queries: ["q"],
-    maxResults: 3,
-    options,
-  });
-  expect(result.status).toBe("ok");
-  expect(requests).toEqual([
-    { path: "/google/search", body: { q: "q", ...options } },
-  ]);
-  expect(result.results[0]).toMatchObject({
-    ok: true,
-    value: {
-      results: [
-        {
-          title: "Example",
-          url: "https://example.com",
-          snippet: "Result",
-          metadata: { rank: 1 },
+        path,
+        body: {
+          ...(mode === "maps-detail"
+            ? { feature_id: row.feature_id }
+            : { q: "q" }),
+          hl: "de",
+          gl: "de",
+          ...extra,
         },
-      ],
-    },
-  });
-});
+      },
+    ]);
+    expect(result.results[0]).toMatchObject({
+      ok: true,
+      value: {
+        results: [
+          { title: "Example", url: "https://example.com", metadata: { mode } },
+        ],
+      },
+    });
+  },
+);
 
 it("forwards You.com's POST search controls through its HTTP adapter", async () => {
   response = { results: { web: [], news: [] }, metadata: { query: "q" } };

--- a/test/provider-sdk-wire.test.ts
+++ b/test/provider-sdk-wire.test.ts
@@ -41,6 +41,44 @@ function client(provider: ProviderId) {
   });
 }
 
+it("forwards SerpBase's native options to one Google search page", async () => {
+  response = {
+    status: 0,
+    organic: [
+      {
+        rank: 1,
+        title: "Example",
+        link: "https://example.com",
+        snippet: "Result",
+      },
+    ],
+  };
+  const options = { hl: "de", gl: "de", page: 2, device: "mobile" };
+  const result = await client("serpbase").search({
+    provider: "serpbase",
+    queries: ["q"],
+    maxResults: 3,
+    options,
+  });
+  expect(result.status).toBe("ok");
+  expect(requests).toEqual([
+    { path: "/google/search", body: { q: "q", ...options } },
+  ]);
+  expect(result.results[0]).toMatchObject({
+    ok: true,
+    value: {
+      results: [
+        {
+          title: "Example",
+          url: "https://example.com",
+          snippet: "Result",
+          metadata: { rank: 1 },
+        },
+      ],
+    },
+  });
+});
+
 it("forwards You.com's POST search controls through its HTTP adapter", async () => {
   response = { results: { web: [], news: [] }, metadata: { query: "q" } };
   const options = {

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, it, vi } from "vitest";
 import { createWebfox } from "../src/index.js";
 import { executeAsyncResearch } from "../src/runtime/polling.js";
 import { WebfoxError } from "../src/errors.js";
+import { providers } from "../src/providers/registry.js";
 const { markdown } = vi.hoisted(() => ({ markdown: vi.fn() }));
 vi.mock("cloudflare", () => ({
   default: class {
@@ -13,6 +14,49 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.clearAllMocks();
 });
+it.each([
+  ["serpbase", undefined, undefined, 120_000],
+  ["serpbase", 45_000, undefined, 45_000],
+  ["serpbase", 45_000, 15_000, 15_000],
+  ["serper", undefined, undefined, 30_000],
+] as const)(
+  "uses request > configuration > provider > global timeout for %s (%s, %s)",
+  async (provider, configured, requested, expected) => {
+    await providers[provider].load();
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_url, init) => {
+        signal = init.signal;
+        return new Promise((_resolve, reject) => {
+          signal!.addEventListener("abort", () => reject(signal!.reason), {
+            once: true,
+          });
+        });
+      }),
+    );
+    const client = createWebfox({
+      config: { execution: { timeoutMs: configured } },
+      env: { SERPBASE_API_KEY: "key", SERPER_API_KEY: "key" },
+    });
+    const pending = client.search({
+      provider,
+      queries: ["slow search"],
+      timeoutMs: requested,
+    });
+    await vi.advanceTimersByTimeAsync(expected - 1);
+    expect(signal).toBeDefined();
+    expect(signal!.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(signal!.aborted).toBe(true);
+    expect((await pending).results[0]).toMatchObject({
+      ok: false,
+      error: { code: "TIMEOUT" },
+    });
+  },
+);
+
 it("retries structurally transient per-page failures on safe adapters", async () => {
   markdown
     .mockRejectedValueOnce(

--- a/test/serpbase-modes.test.ts
+++ b/test/serpbase-modes.test.ts
@@ -1,0 +1,398 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createWebfox } from "../src/index.js";
+import { renderTextDocument } from "../src/render.js";
+import {
+  SERPBASE_MODES,
+  type SerpBaseMode,
+} from "../src/providers/serpbase/types.js";
+
+const featureId = "0x123:0x456";
+const place = {
+  name: "Example Cafe",
+  feature_id: featureId,
+  google_maps_url: "https://maps.google.com/example",
+  website: "https://cafe.example.com",
+  address: "Main Street 1",
+  phone: "+49 123",
+  rating: 4.5,
+  latitude: 52.5,
+  longitude: 13.4,
+  types: ["Cafe"],
+  hours: { Monday: "09:00–17:00" },
+  open_status: { text: "Open" },
+  attributes: [{ name: "Wi-Fi" }],
+};
+const fixtures: Record<SerpBaseMode, unknown> = {
+  search: {
+    status: 0,
+    organic: [
+      {
+        title: "Organic",
+        link: "https://organic.test",
+        rank: 2,
+        snippet: "Summary",
+      },
+    ],
+  },
+  images: {
+    status: 0,
+    images: [
+      {
+        title: "Image",
+        link: "https://source.test",
+        image_url: "https://image.test/full.jpg",
+        thumbnail_url: "https://image.test/thumb.jpg",
+        source: "Image publisher",
+      },
+    ],
+  },
+  news: {
+    status: 0,
+    news: [
+      {
+        title: "Article",
+        link: "https://news.test",
+        source: "Publisher",
+        time: "2 hours ago",
+        snippet: "Article summary",
+      },
+    ],
+  },
+  videos: {
+    status: 0,
+    videos: [
+      {
+        title: "Tutorial",
+        link: "https://video.test",
+        source: "Channel",
+        duration: "10:30",
+        published_at: "Yesterday",
+        thumbnail: "https://video.test/thumb.jpg",
+      },
+    ],
+  },
+  maps: { status: 0, places: [place] },
+  "maps-detail": { status: 0, place },
+};
+function client(options: Record<string, unknown> = {}) {
+  return createWebfox({
+    config: {
+      defaults: { search: { provider: "serpbase" } },
+      providers: { serpbase: { options: { search: options } } },
+    },
+    env: { SERPBASE_API_KEY: "test-key" },
+  });
+}
+function mock(body: unknown) {
+  const fetch = vi.fn().mockImplementation(async () => Response.json(body));
+  vi.stubGlobal("fetch", fetch);
+  return fetch;
+}
+afterEach(() => vi.unstubAllGlobals());
+
+describe("SerpBase modes", () => {
+  it.each(Object.keys(SERPBASE_MODES) as SerpBaseMode[])(
+    "routes %s through the existing search capability with native fields",
+    async (mode) => {
+      const fetch = mock(fixtures[mode]);
+      const result = await client().search({
+        queries: [mode === "maps-detail" ? featureId : "query"],
+        maxResults: 1,
+        options: { mode },
+      });
+      expect(result.status).toBe("ok");
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(fetch.mock.calls[0][0]).toBe(
+        `https://api.serpbase.dev/google/${SERPBASE_MODES[mode].path}`,
+      );
+      expect(JSON.parse(fetch.mock.calls[0][1].body)).toEqual({
+        ...(mode === "maps-detail"
+          ? { feature_id: featureId }
+          : { q: "query", page: 1 }),
+        hl: "en",
+        gl: "us",
+        ...(mode === "search" ? { device: "default" } : {}),
+      });
+      expect(result.results[0]).toMatchObject({
+        ok: true,
+        value: {
+          results: [{ metadata: { mode, searchContext: { status: 0 } } }],
+        },
+      });
+      const content = renderTextDocument(result);
+      const required: Record<SerpBaseMode, string[]> = {
+        search: ["Organic", "https://organic.test", "Summary"],
+        images: [
+          "https://source.test",
+          "Image URL: https://image.test/full.jpg",
+          "Thumbnail: https://image.test/thumb.jpg",
+          "Image publisher",
+        ],
+        news: ["Publisher", "2 hours ago", "Article summary"],
+        videos: ["Channel", "Duration: 10:30", "Published: Yesterday"],
+        maps: [
+          "Example Cafe",
+          `feature_id: ${featureId}`,
+          "Main Street 1",
+          "Rating: 4.5",
+          "+49 123",
+          "https://cafe.example.com",
+          "52.5, 13.4",
+          "09:00–17:00",
+        ],
+        "maps-detail": [
+          `feature_id: ${featureId}`,
+          "Main Street 1",
+          "Wi-Fi",
+          "Hours:",
+          "Open status:",
+        ],
+      };
+      for (const value of required[mode]) expect(content).toContain(value);
+      expect(content).not.toContain("[object Object]");
+      const row = result.results[0];
+      if (!row.ok) throw new Error("Expected success");
+      for (const endpoint of Object.values(SERPBASE_MODES))
+        expect(row.value.results[0].metadata!.searchContext).not.toHaveProperty(
+          endpoint.result,
+        );
+    },
+  );
+
+  it("supports mode-specific configured defaults and preserves compatible defaults on overrides", async () => {
+    const fetch = mock(fixtures.news);
+    await client({ mode: "news", page: 3, gl: "de" }).search({
+      queries: ["news"],
+    });
+    expect(JSON.parse(fetch.mock.lastCall![1].body)).toEqual({
+      q: "news",
+      page: 3,
+      hl: "en",
+      gl: "de",
+    });
+    await client({ device: "pc", page: 2, hl: "de" }).search({
+      queries: ["news"],
+      options: { mode: "news" },
+    });
+    expect(JSON.parse(fetch.mock.lastCall![1].body)).toEqual({
+      q: "news",
+      page: 2,
+      hl: "de",
+      gl: "us",
+    });
+    await client({ mode: "maps", lat: 52.5, lng: 13.4, zoom: 14 }).search({
+      queries: ["news"],
+      options: { mode: "news" },
+    });
+    expect(JSON.parse(fetch.mock.lastCall![1].body)).toEqual({
+      q: "news",
+      page: 1,
+      hl: "en",
+      gl: "us",
+    });
+    // Explicit incompatible controls aren't silently ignored.
+    await expect(
+      client({ device: "pc" }).search({
+        queries: ["news"],
+        options: { mode: "news", device: "mobile" },
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("merges coordinate defaults and overrides before enforcing their dependency", async () => {
+    const fetch = mock(fixtures.maps);
+    await client({ mode: "maps", lat: 0 }).search({
+      queries: ["coffee"],
+      options: { lng: 0, zoom: 1 },
+    });
+    expect(JSON.parse(fetch.mock.lastCall![1].body)).toEqual({
+      q: "coffee",
+      hl: "en",
+      gl: "us",
+      page: 1,
+      lat: 0,
+      lng: 0,
+      zoom: 1,
+    });
+    await client({ mode: "maps", lat: 90, lng: -180 }).search({
+      queries: ["coffee"],
+      options: { zoom: 21 },
+    });
+    expect(JSON.parse(fetch.mock.lastCall![1].body)).toMatchObject({
+      lat: 90,
+      lng: -180,
+      zoom: 21,
+    });
+    for (const options of [
+      { lat: 0 },
+      { lng: 0 },
+      { zoom: 14 },
+      { lat: 0, zoom: 14 },
+    ]) {
+      await expect(
+        client().search({
+          queries: ["coffee"],
+          options: { mode: "maps", ...options },
+        }),
+      ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    }
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    "coffee",
+    "ChIJabc",
+    "123456",
+    "https://maps.google.com/",
+    "0xZZ:0x123",
+  ])("rejects invalid maps-detail input %s before transport", async (query) => {
+    const fetch = mock(fixtures["maps-detail"]);
+    const result = await client().search({
+      queries: [query],
+      options: { mode: "maps-detail" },
+    });
+    expect(result.results[0]).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_INPUT",
+        message: expect.stringContaining("feature_id"),
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("looks up each feature ID independently and preserves batch order", async () => {
+    const fetch = mock(fixtures["maps-detail"]);
+    const ids = ["0x123:0x456", "0xabc:0xDEF"];
+    const result = await client().search({
+      queries: ids,
+      options: { mode: "maps-detail" },
+    });
+    expect(result.results.map((entry) => entry.input)).toEqual(ids);
+    expect(fetch.mock.calls.map(([, init]) => JSON.parse(init.body))).toEqual(
+      ids.map((feature_id) => ({ feature_id, hl: "en", gl: "us" })),
+    );
+  });
+
+  it.each(Object.keys(SERPBASE_MODES) as SerpBaseMode[])(
+    "rejects malformed %s collections and accepts missing optional collections",
+    async (mode) => {
+      const query = mode === "maps-detail" ? featureId : "query";
+      mock({
+        status: 0,
+        [SERPBASE_MODES[mode].result]: mode === "maps-detail" ? [] : {},
+      });
+      const failed = await client().search({
+        queries: [query],
+        options: { mode },
+      });
+      expect(failed.results[0]).toMatchObject({
+        ok: false,
+        error: { code: "PROVIDER_FAILURE", retryable: false },
+      });
+      mock({ status: 0 });
+      const empty = await client().search({
+        queries: [query],
+        options: { mode },
+      });
+      expect(empty.results[0]).toMatchObject({
+        ok: true,
+        value: { results: [] },
+      });
+    },
+  );
+
+  it("filters the observed navigation logo before limiting images without filtering Google content", async () => {
+    mock({
+      status: 0,
+      images: [
+        {
+          title: "Google",
+          link: "https://www.google.com/?tbm=isch",
+          image_url: "https://www.gstatic.com/m/images/icons/googleg.gif",
+          rank: 1,
+        },
+        {
+          title: "Photo",
+          link: "https://photo.test",
+          image_url: "https://photo.test/full.jpg",
+          rank: 2,
+        },
+        {
+          title: "Logo article",
+          link: "https://www.google.com/about/",
+          image_url: "https://www.gstatic.com/m/images/icons/googleg.gif",
+          rank: 3,
+        },
+      ],
+    });
+    const result = await client().search({
+      queries: ["photos"],
+      maxResults: 2,
+      options: { mode: "images" },
+    });
+    const entry = result.results[0];
+    if (!entry.ok) throw new Error("Expected success");
+    expect(entry.value.results.map((row) => row.title)).toEqual([
+      "Photo",
+      "Logo article",
+    ]);
+    expect(entry.value.results.map((row) => row.metadata?.rank)).toEqual([
+      2, 3,
+    ]);
+  });
+
+  it("does not invent publication dates or durations from malformed upstream video time fields", async () => {
+    mock({
+      status: 0,
+      videos: [
+        {
+          title: "Video",
+          link: "https://video.test",
+          snippet: "Duration: Posted:",
+          published_at: "7:13",
+          time: "7:13",
+        },
+      ],
+    });
+    const result = await client().search({
+      queries: ["tutorial"],
+      options: { mode: "videos" },
+    });
+    const text = renderTextDocument(result);
+    expect(text).toContain("Time (upstream): 7:13");
+    expect(text).not.toContain("Published:");
+    expect(text).not.toContain("Duration:");
+    expect(result.results[0]).toMatchObject({
+      ok: true,
+      value: {
+        results: [{ metadata: { published_at: "7:13", time: "7:13" } }],
+      },
+    });
+  });
+
+  it("retains images without a source URL and places without a Maps URL", async () => {
+    mock({ status: 0, images: [{ image_url: "https://image.test/full.jpg" }] });
+    const image = await client().search({
+      queries: ["image"],
+      options: { mode: "images" },
+    });
+    expect(image.results[0]).toMatchObject({
+      ok: true,
+      value: { results: [{ url: "https://image.test/full.jpg" }] },
+    });
+    mock({ status: 0, places: [{ name: "Cafe", feature_id: featureId }] });
+    const maps = await client().search({
+      queries: ["cafe"],
+      options: { mode: "maps" },
+    });
+    expect(renderTextDocument(maps)).toContain(`feature_id: ${featureId}`);
+    expect(maps.results[0]).toMatchObject({
+      ok: true,
+      value: {
+        results: [{ url: "https://www.google.com/maps?ftid=0x123%3A0x456" }],
+      },
+    });
+  });
+});

--- a/test/serpbase-provider.test.ts
+++ b/test/serpbase-provider.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Check } from "typebox/value";
+import { createWebfox, validateConfiguredOptions } from "../src/index.js";
+import { validateOptions } from "../src/configuration/planning.js";
+import { configurationSchema } from "../src/configuration/schema.js";
+import { adapter } from "../src/providers/serpbase/adapter.js";
+import { serpbaseProvider } from "../src/providers/serpbase/definition.js";
+
+// Wire contract: https://serpbase.dev/docs, including the business-status envelope.
+const organic = {
+  rank: 1,
+  position: 1,
+  title: "Node.js",
+  link: "https://nodejs.org/api/globals.html",
+  url: "https://nodejs.org/alias",
+  snippet: "AbortSignal\n documentation",
+  sitelinks: [{ title: "API", link: "https://nodejs.org/api/" }],
+};
+const context = {
+  status: 0,
+  query: "Node.js AbortSignal",
+  page: 2,
+  request_id: "request-123",
+  elapsed_ms: 123,
+  credits_charged: 1,
+  search_type: "search",
+  people_also_ask: [{ question: "What is AbortSignal?" }],
+  related_searches: ["Node.js cancellation"],
+  featured_snippet: { answer: "A cancellation signal" },
+};
+const payload = { ...context, organic: [organic] };
+function mockResponse(body: unknown = payload, status = 200) {
+  return vi
+    .fn()
+    .mockImplementation(async () => Response.json(body, { status }));
+}
+function client(options: Record<string, unknown> = {}, retries = 0) {
+  return createWebfox({
+    config: {
+      defaults: { search: { provider: "serpbase" } },
+      execution: { retries, retryDelayMs: 0 },
+      providers: { serpbase: { options: { search: options } } },
+    },
+    env: { SERPBASE_API_KEY: "test-key" },
+  });
+}
+const request = {
+  capability: "search",
+  query: "example",
+  maxResults: 5,
+} as const;
+const config = { credentials: { api: "test-key" } };
+const providerContext = { cwd: process.cwd() };
+afterEach(() => vi.unstubAllGlobals());
+
+describe("SerpBase search", () => {
+  it("exposes credentials and options without initializing transport", () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    expect(client().getProvider("serpbase")).toMatchObject({
+      capabilities: ["search"],
+      configured: ["search"],
+      selectedDefaults: ["search"],
+      credentials: [{ name: "api", environmentVariable: "SERPBASE_API_KEY" }],
+    });
+    expect(client().inspectCapability("search")).toMatchObject({
+      defaults: { options: { hl: "en", gl: "us", page: 1, device: "default" } },
+      optionSchema: {
+        additionalProperties: false,
+        properties: { device: { enum: ["default", "pc", "mobile"] } },
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("maps the POST contract, merged options, organic links, and context", async () => {
+    const fetch = mockResponse();
+    vi.stubGlobal("fetch", fetch);
+    const result = await client({ gl: "de", hl: "de", device: "pc" }).search({
+      queries: [context.query],
+      maxResults: 3,
+      options: { hl: "en", page: 2 },
+    });
+    expect(fetch).toHaveBeenCalledOnce();
+    const [url, init] = fetch.mock.calls[0];
+    expect(url).toBe("https://api.serpbase.dev/google/search");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({
+      "content-type": "application/json",
+      "X-API-Key": "test-key",
+    });
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+    expect(JSON.parse(init.body)).toEqual({
+      q: context.query,
+      hl: "en",
+      gl: "de",
+      page: 2,
+      device: "pc",
+    });
+    expect(result.status).toBe("ok");
+    expect(result.results[0]).toMatchObject({
+      ok: true,
+      value: {
+        results: [
+          {
+            title: organic.title,
+            url: organic.link,
+            snippet: "AbortSignal documentation",
+            metadata: {
+              rank: 1,
+              position: 1,
+              sitelinks: organic.sitelinks,
+              searchContext: context,
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it("sends the documented defaults", async () => {
+    const fetch = mockResponse();
+    vi.stubGlobal("fetch", fetch);
+    await client().search({ queries: ["example"] });
+    expect(JSON.parse(fetch.mock.calls[0][1].body)).toEqual({
+      q: "example",
+      hl: "en",
+      gl: "us",
+      page: 1,
+      device: "default",
+    });
+  });
+
+  it.each([1, 3, 50])(
+    "limits one page locally to %i results without reordering or pagination",
+    async (maxResults) => {
+      const entries = [3, 1, 2].map((rank) => ({
+        ...organic,
+        rank,
+        title: `Result ${rank}`,
+      }));
+      const fetch = mockResponse({ ...payload, organic: entries });
+      vi.stubGlobal("fetch", fetch);
+      const result = await adapter.search(
+        { ...request, maxResults },
+        config,
+        providerContext,
+      );
+      expect(result.results.map((entry) => entry.metadata?.rank)).toEqual(
+        [3, 1, 2].slice(0, maxResults),
+      );
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(JSON.parse(fetch.mock.calls[0][1].body)).toEqual({ q: "example" });
+    },
+  );
+
+  it("handles absent results, aliases, missing snippets, and malformed rows", async () => {
+    const fetch = mockResponse({
+      ...payload,
+      organic: [
+        null,
+        42,
+        [],
+        {},
+        { title: "No link" },
+        { url: "https://example.com", link: "", snippet: 42 },
+        { ...organic, snippet: "x".repeat(1000) },
+      ],
+    });
+    vi.stubGlobal("fetch", fetch);
+    const result = await adapter.search(request, config, providerContext);
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toMatchObject({
+      title: "https://example.com",
+      url: "https://example.com",
+      snippet: "",
+    });
+    expect(result.results[1].snippet).toHaveLength(300);
+    for (const body of [{ status: 0 }, { status: 0, organic: [] }]) {
+      vi.stubGlobal("fetch", mockResponse(body));
+      expect(
+        (await adapter.search(request, config, providerContext)).results,
+      ).toEqual([]);
+    }
+  });
+
+  it("supports a custom origin and propagates cancellation", async () => {
+    const controller = new AbortController();
+    const fetch = vi.fn().mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init.signal.addEventListener(
+            "abort",
+            () => reject(init.signal.reason),
+            { once: true },
+          );
+        }),
+    );
+    vi.stubGlobal("fetch", fetch);
+    const pending = adapter.search(
+      request,
+      { ...config, baseUrl: "https://proxy.example.com///" },
+      { ...providerContext, signal: controller.signal },
+    );
+    expect(fetch.mock.calls[0][0]).toBe(
+      "https://proxy.example.com/google/search",
+    );
+    expect(fetch.mock.calls[0][1].signal).toBe(controller.signal);
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it.each([400, 401, 402, 429, 500, 502, 503, 504])(
+    "classifies and redacts HTTP %i failures",
+    async (status) => {
+      vi.stubGlobal(
+        "fetch",
+        mockResponse({ error: "request failed for test-key" }, status),
+      );
+      const result = await client().search({ queries: ["example"] });
+      expect(result.results[0]).toMatchObject({
+        ok: false,
+        error: {
+          code: "PROVIDER_FAILURE",
+          retryable: status === 429 || status >= 500,
+        },
+      });
+      expect(JSON.stringify(result)).not.toContain("test-key");
+      expect(JSON.stringify(result)).toContain(`HTTP ${status}`);
+    },
+  );
+
+  it.each([1000, 1001, 1004, 1020, 1029, 1500, 1502, 1503, 1504])(
+    "handles business status %i even with HTTP 200",
+    async (status) => {
+      vi.stubGlobal(
+        "fetch",
+        mockResponse({ status, error: "request failed for test-key" }),
+      );
+      const result = await client().search({ queries: ["example"] });
+      expect(result.results[0]).toMatchObject({
+        ok: false,
+        error: {
+          code: "PROVIDER_FAILURE",
+          retryable: [1029, 1500, 1502, 1503, 1504].includes(status),
+        },
+      });
+      expect(JSON.stringify(result)).not.toContain("test-key");
+      expect(JSON.stringify(result)).toContain(`status ${status}`);
+    },
+  );
+
+  it("retries transient business errors through the shared runtime, but not insufficient credits", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({ status: 1029, error: "rate limited" }),
+      )
+      .mockResolvedValueOnce(Response.json(payload));
+    vi.stubGlobal("fetch", fetch);
+    expect((await client({}, 1).search({ queries: ["example"] })).status).toBe(
+      "ok",
+    );
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const denied = mockResponse(
+      { status: 1020, error: "insufficient credits" },
+      503,
+    );
+    vi.stubGlobal("fetch", denied);
+    expect((await client({}, 1).search({ queries: ["example"] })).status).toBe(
+      "partial",
+    );
+    expect(denied).toHaveBeenCalledOnce();
+  });
+
+  it.each([null, [], {}, { status: "0" }, { status: 0, organic: {} }])(
+    "rejects malformed success envelopes: %j",
+    async (body) => {
+      vi.stubGlobal("fetch", mockResponse(body));
+      await expect(
+        adapter.search(request, config, providerContext),
+      ).rejects.toMatchObject({
+        code: "PROVIDER_FAILURE",
+        options: { retryable: false },
+      });
+    },
+  );
+
+  it.each([200, 401, 503])(
+    "handles non-JSON HTTP %i responses",
+    async (status) => {
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValue(new Response("upstream unavailable", { status })),
+      );
+      await expect(
+        adapter.search(request, config, providerContext),
+      ).rejects.toMatchObject({
+        code: "PROVIDER_FAILURE",
+        options: { retryable: status === 503 },
+      });
+    },
+  );
+
+  it("rejects missing credentials and unsupported capabilities without requests", async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    await expect(
+      createWebfox({ config: {}, env: {} }).search({
+        provider: "serpbase",
+        queries: ["example"],
+      }),
+    ).rejects.toMatchObject({ code: "PROVIDER_UNAVAILABLE" });
+    await expect(adapter.search(request, {}, providerContext)).rejects.toThrow(
+      "missing an API key",
+    );
+    await expect(
+      client().answer({ provider: "serpbase", queries: ["example"] }),
+    ).rejects.toMatchObject({ code: "PROVIDER_UNAVAILABLE" });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { device: "desktop" },
+    { device: "" },
+    { page: 0 },
+    { page: 1.5 },
+    { page: "2" },
+    { hl: "" },
+    { gl: 123 },
+    { num: 10 },
+    { q: "override" },
+    { mode: "images" },
+  ])("rejects invalid options before requests: %j", async (options) => {
+    const fetch = vi.fn();
+    vi.stubGlobal("fetch", fetch);
+    expect(() =>
+      validateOptions(serpbaseProvider, "search", options),
+    ).toThrow();
+    const configured = {
+      providers: { serpbase: { options: { search: options } } },
+    };
+    expect(() => validateConfiguredOptions(configured)).toThrow();
+    expect(Check(configurationSchema, configured)).toBe(false);
+    await expect(
+      client().search({ queries: ["example"], options }),
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/test/serpbase-provider.test.ts
+++ b/test/serpbase-provider.test.ts
@@ -332,7 +332,17 @@ describe("SerpBase search", () => {
     { gl: 123 },
     { num: 10 },
     { q: "override" },
-    { mode: "images" },
+    { mode: "unsupported" },
+    { mode: "images", device: "pc" },
+    { mode: "news", lat: 0, lng: 0 },
+    { mode: "videos", zoom: 14 },
+    { mode: "maps", device: "mobile" },
+    { mode: "maps", lat: 91 },
+    { mode: "maps", lng: -181 },
+    { mode: "maps", zoom: 22 },
+    { mode: "maps", zoom: 1.5 },
+    { mode: "maps-detail", page: 1 },
+    { mode: "maps-detail", lat: 0, lng: 0 },
   ])("rejects invalid options before requests: %j", async (options) => {
     const fetch = vi.fn();
     vi.stubGlobal("fetch", fetch);


### PR DESCRIPTION
## 🔍 Problem

- SerpBase users cannot use their existing API key through webfox, including Google's specialized search endpoints.

## 🛠️ Solution

- Cover all six endpoints through the existing `search` capability and **one `web_search` tool**: `search`, `images`, `news`, `videos`, `maps`, and `maps-detail`.
- Expose typed native options and mode-aware validation/defaults. Maps Detail takes feature IDs from Maps Search in `queries`, without dummy queries or additional tools.
- Include media URLs, sources, feature IDs, contact information, and place details in model-visible text; retain richer metadata in JSON. Connect provider guidance to tool descriptions.
- Keep each input to one page or place, with local result limiting, cancellation, and business-status-aware retries. SerpBase defaults to a 120-second overall deadline; explicit request/configuration deadlines take precedence and other providers are unchanged. Use direct HTTP with no additional SDK dependency.

## 💬 Review

- 471 tests pass locally, including fake-timer checks of cancellation deadlines and timeout precedence. Wire tests cover all six endpoints; Pi tests verify only `web_search` is registered and follow a feature ID from model-visible Maps output into Maps Detail.
- [PR CI](https://github.com/mavam/webfox/actions/runs/34471550528) is green on Node.js 22, 24, and 26, including formatting and the installed CLI/Pi package smoke test.
- [Manual CI with a live Maps search](https://github.com/mavam/webfox/actions/runs/34469632856) passed on commit `8f3a302`, using the environment-scoped `SERPBASE_API_KEY`. Latest local news/maps retries with the longer default returned upstream `1503: service unavailable`, rather than a client timeout.
- Real local API checks passed for every endpoint, including Maps → Maps Detail, plus desktop/mobile and page-2 organic results. Initial detail timeout and concurrent-call throttling were observed; a sequential detail retry succeeded.
- Live responses exposed a Google navigation-logo artifact and ambiguous video time fields. Narrow regression-tested handling excludes the navigation asset and avoids inventing publication dates or durations.
- Empty result lists still have no per-result context; upstream data quality, latency, and account limits remain provider-dependent.

<sub>✅ Closes #45</sub>
