### PR TITLE
Document Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ configuration in your terminal, TypeScript applications, and pi.
 
 ## 🚀 Installation
 
-- **Terminal:** Install the `web` command:
+- **Terminal:** Install the `web` command with [Homebrew](https://github.com/mavam/homebrew-tap):
+
+  ```sh
+  brew install mavam/tap/webfox
+  ```
+
+  Or use npm:
 
   ```sh
   npm install -g webfox
@@ -37,6 +43,7 @@ configuration in your terminal, TypeScript applications, and pi.
   pi install npm:webfox
   ```
 
+  This installs the extension, not the `web` command on your shell's `PATH`.
   Then follow [Use with Pi](#-use-with-pi) to select a web provider and supply its
   API key.
 
@@ -205,6 +212,9 @@ Install the [Pi](https://pi.dev) extension:
 ```sh
 pi install npm:webfox
 ```
+
+To also use the `web` command in your terminal, follow [Installation](#-installation).
+Both installations share the same Webfox configuration.
 
 Add to `~/.config/webfox/config.yaml`:
 

--- a/changelog/unreleased/homebrew-installation-for-the-web-command.md
+++ b/changelog/unreleased/homebrew-installation-for-the-web-command.md
@@ -1,0 +1,20 @@
+---
+title: Homebrew installation for the web command
+type: feature
+authors:
+  - mavam
+prs:
+  - 47
+created: 2026-09-11T05:28:09.483988Z
+---
+
+You can now install the `web` command with Homebrew on macOS and Linux:
+
+```sh
+brew install mavam/tap/webfox
+```
+
+Homebrew manages Node.js and the command's dependencies. The npm installation
+option remains available. To use Webfox in Pi, install the extension separately
+with `pi install npm:webfox`; this doesn't add `web` to your shell's `PATH`.
+The CLI and Pi extension share the same Webfox configuration.


### PR DESCRIPTION
## 🔍 Problem

The Homebrew tap is live, but installation instructions only describe npm for the CLI. Pi users can also mistake extension installation for installation of the `web` shell command.

## 🛠️ Solution

- Document `brew install mavam/tap/webfox`, keeping npm as an alternative.
- Clarify separate CLI and Pi installation with shared configuration.
- Announce Homebrew availability in the changelog.

## 💬 Review

Documentation only; no runtime or release-pipeline changes. The tap already checks for releases daily.

Validation: formatting, TypeScript, all 471 tests, changelog validation, and actionlint passed. The tap's macOS and Linux installation tests also passed.

<sub>🍺 Tap: https://github.com/mavam/homebrew-tap</sub>
